### PR TITLE
fix: improve ergonomics when referring to functions from quoted code

### DIFF
--- a/stageleft_test/Cargo.toml
+++ b/stageleft_test/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.0.0"
 edition = "2024"
 
 [features]
-stageleft_devel = []
 test_feature = []
 
 [dependencies]

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(stageleft_macro, allow(dead_code))]
 stageleft::stageleft_crate!(stageleft_test_macro);
 
 use stageleft::{BorrowBounds, IntoQuotedOnce, Quoted, RuntimeData, q};
@@ -43,6 +44,20 @@ fn crate_paths<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
     q!(crate::my_top_level_function())
 }
 
+#[stageleft::entry]
+fn local_paths<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
+    q!(my_top_level_function())
+}
+
+#[stageleft::entry]
+fn captured_closure<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
+    let closure = q!(|| true);
+    q!({
+        let closure = closure;
+        closure()
+    })
+}
+
 #[cfg(stageleft_runtime)]
 #[cfg(test)]
 mod tests {
@@ -67,6 +82,21 @@ mod tests {
     }
 
     #[test]
+    fn test_crate_paths() {
+        assert!(crate_paths!());
+    }
+
+    #[test]
+    fn test_local_paths() {
+        assert!(local_paths!());
+    }
+
+    #[test]
+    fn test_captured_closure() {
+        assert!(captured_closure!());
+    }
+
+    #[test]
     fn test_submodule_private_struct() {
         let result = submodule::private_struct!();
         assert_eq!(result, 1);
@@ -74,7 +104,7 @@ mod tests {
 
     #[test]
     fn test_submodule_public_struct() {
-        let result = submodule::public_struct!();
+        let result: submodule::PublicStruct = submodule::public_struct!();
         assert_eq!(result.a, 1);
     }
 }

--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -409,15 +409,15 @@ pub fn gen_final_helper() {
 #[macro_export]
 macro_rules! gen_final {
     () => {
+        println!("cargo::rustc-check-cfg=cfg(stageleft_macro)");
+        println!("cargo::rustc-check-cfg=cfg(stageleft_runtime)");
+        println!("cargo::rustc-cfg=stageleft_runtime");
+
         #[allow(
             unexpected_cfgs,
             reason = "Consumer crates may optionally add the `stageleft_devel` feature."
         )]
         {
-            println!("cargo::rustc-check-cfg=cfg(stageleft_macro)");
-            println!("cargo::rustc-check-cfg=cfg(stageleft_runtime)");
-            println!("cargo::rustc-cfg=stageleft_runtime");
-
             #[cfg(not(feature = "stageleft_devel"))]
             $crate::gen_final_helper()
         }


### PR DESCRIPTION

Previously, we would treat a function call like `xyz(...)` as `xyz` being a free variable. This is correct if `xyz` is another piece of quoted code, but more frequently in user code `xyz` is just some external function. This switches the default to assuming that it is an external function, but when using captured functions `let a = xyz;` can be used.
