### PR TITLE
feat: make code-completion work with Rust Analyzer

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -308,7 +308,7 @@ pub trait IntoQuotedOnce<'a, T, Ctx>:
         &'b Ctx,
         &mut String,
         &mut &'static str,
-        &mut TokenStream,
+        &mut &'static str,
         &mut CaptureVec,
         bool,
     ) -> T
@@ -331,7 +331,7 @@ impl<
             &'b Ctx,
             &mut String,
             &mut &'static str,
-            &mut TokenStream,
+            &mut &'static str,
             &mut CaptureVec,
             bool,
         ) -> T
@@ -348,7 +348,7 @@ impl<
             &'b Ctx,
             &mut String,
             &mut &'static str,
-            &mut TokenStream,
+            &mut &'static str,
             &mut CaptureVec,
             bool,
         ) -> T
@@ -364,7 +364,7 @@ impl<
         &'b Ctx,
         &mut String,
         &mut &'static str,
-        &mut TokenStream,
+        &mut &'static str,
         &mut CaptureVec,
         bool,
     ) -> T,
@@ -375,7 +375,7 @@ impl<
     fn to_tokens(self, ctx: &Ctx) -> (Option<TokenStream>, Option<TokenStream>) {
         let mut module_path = String::new();
         let mut crate_name = "";
-        let mut expr_tokens = TokenStream::new();
+        let mut expr_tokens = "";
         let mut free_variables = Vec::new();
         // this is an uninit value so we can't drop it
         std::mem::forget(self(
@@ -419,7 +419,7 @@ impl<
             })
         };
 
-        let expr: syn::Expr = syn::parse2(expr_tokens).unwrap();
+        let expr: syn::Expr = syn::parse_str(expr_tokens).unwrap();
         let with_env = if let Some(module_path) = module_path {
             quote!({
                 use #final_crate_root::__staged::__deps::*;
@@ -441,7 +441,7 @@ impl<
 }
 
 pub trait IntoQuotedMut<'a, T, Ctx>:
-    FnMut(&Ctx, &mut String, &mut &'static str, &mut TokenStream, &mut CaptureVec, bool) -> T + 'a
+    FnMut(&Ctx, &mut String, &mut &'static str, &mut &'static str, &mut CaptureVec, bool) -> T + 'a
 {
 }
 
@@ -449,7 +449,7 @@ impl<
     'a,
     T,
     Ctx,
-    F: FnMut(&Ctx, &mut String, &mut &'static str, &mut TokenStream, &mut CaptureVec, bool) -> T + 'a,
+    F: FnMut(&Ctx, &mut String, &mut &'static str, &mut &'static str, &mut CaptureVec, bool) -> T + 'a,
 > IntoQuotedMut<'a, T, Ctx> for F
 {
 }

--- a/stageleft_macro/Cargo.toml
+++ b/stageleft_macro/Cargo.toml
@@ -19,7 +19,6 @@ syn = { version = "2.0.46", features = [
     "full",
     "parsing",
     "visit",
-    "visit-mut",
 ] }
 proc-macro2 = "1.0.74"
 proc-macro-crate = "1.0.0"

--- a/stageleft_macro/src/lib.rs
+++ b/stageleft_macro/src/lib.rs
@@ -26,9 +26,7 @@ pub fn q(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
     };
 
-    let expr = syn::parse_macro_input!(input as syn::Expr);
-
-    proc_macro::TokenStream::from(quote_impl::q_impl(root, expr))
+    proc_macro::TokenStream::from(quote_impl::q_impl(root, input.into()))
 }
 
 fn gen_use_paths(

--- a/stageleft_macro/src/quote_impl/free_variable/mod.rs
+++ b/stageleft_macro/src/quote_impl/free_variable/mod.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeSet, HashSet};
 
 mod prelude;
 use prelude::is_prelude;
-use quote::ToTokens;
 
 #[derive(Debug)]
 pub struct ScopeStack {
@@ -65,25 +64,25 @@ pub struct FreeVariableVisitor {
     pub current_scope: ScopeStack,
 }
 
-impl syn::visit_mut::VisitMut for FreeVariableVisitor {
-    fn visit_expr_closure_mut(&mut self, i: &mut syn::ExprClosure) {
+impl syn::visit::Visit<'_> for FreeVariableVisitor {
+    fn visit_expr_closure(&mut self, i: &syn::ExprClosure) {
         self.current_scope.push();
-        i.inputs.iter_mut().for_each(|input| {
-            self.visit_pat_mut(input);
+        i.inputs.iter().for_each(|input| {
+            self.visit_pat(input);
         });
 
-        syn::visit_mut::visit_expr_closure_mut(self, i);
+        syn::visit::visit_expr_closure(self, i);
 
         self.current_scope.pop();
     }
 
-    fn visit_item_fn_mut(&mut self, i: &mut syn::ItemFn) {
+    fn visit_item_fn(&mut self, i: &syn::ItemFn) {
         self.current_scope.push();
-        syn::visit_mut::visit_item_fn_mut(self, i);
+        syn::visit::visit_item_fn(self, i);
         self.current_scope.pop();
     }
 
-    fn visit_generic_param_mut(&mut self, i: &mut syn::GenericParam) {
+    fn visit_generic_param(&mut self, i: &syn::GenericParam) {
         match i {
             syn::GenericParam::Type(type_param) => {
                 self.current_scope.insert_type(type_param.ident.clone());
@@ -98,174 +97,163 @@ impl syn::visit_mut::VisitMut for FreeVariableVisitor {
         }
     }
 
-    fn visit_block_mut(&mut self, i: &mut syn::Block) {
+    fn visit_block(&mut self, i: &syn::Block) {
         self.current_scope.push();
-        syn::visit_mut::visit_block_mut(self, i);
+        syn::visit::visit_block(self, i);
         self.current_scope.pop();
     }
 
-    fn visit_local_mut(&mut self, i: &mut syn::Local) {
-        i.init.iter_mut().for_each(|init| {
-            syn::visit_mut::visit_local_init_mut(self, init);
+    fn visit_local(&mut self, i: &syn::Local) {
+        i.init.iter().for_each(|init| {
+            syn::visit::visit_local_init(self, init);
         });
-
-        match &mut i.pat {
+        match &i.pat {
             syn::Pat::Ident(pat_ident) => {
                 self.current_scope.insert_term(pat_ident.ident.clone());
             }
             syn::Pat::Type(pat_type) => {
-                self.visit_pat_mut(&mut pat_type.pat);
+                self.visit_pat(&pat_type.pat);
             }
             syn::Pat::Wild(_) => {
                 // Do nothing
             }
             syn::Pat::Tuple(pat_tuple) => {
-                for el in &mut pat_tuple.elems {
-                    self.visit_pat_mut(el);
+                for el in &pat_tuple.elems {
+                    self.visit_pat(el);
                 }
             }
             _ => panic!("Local variables must be identifiers, got {:?}", i.pat),
         }
     }
 
-    fn visit_ident_mut(&mut self, i: &mut proc_macro2::Ident) {
+    fn visit_ident(&mut self, i: &proc_macro2::Ident) {
         if !self.current_scope.contains_term(i) {
             self.free_variables.insert(i.clone());
-            *i = syn::Ident::new(&format!("{}__free", i), i.span());
         }
     }
 
-    fn visit_lifetime_mut(&mut self, i: &mut syn::Lifetime) {
+    fn visit_lifetime(&mut self, i: &syn::Lifetime) {
         if !self.current_scope.contains_type(&i.ident) {
             self.free_variables.insert(i.ident.clone());
-            i.ident = syn::Ident::new(&format!("{}__free", i.ident), i.ident.span());
         }
     }
 
-    fn visit_path_mut(&mut self, i: &mut syn::Path) {
+    fn visit_path(&mut self, i: &syn::Path) {
         if i.leading_colon.is_none() && !is_prelude(&i.segments.first().unwrap().ident) {
             let one_segment = i.segments.len() == 1;
-            let node = i.segments.first_mut().unwrap();
+            let node = i.segments.first().unwrap();
             if one_segment && !self.current_scope.contains_term(&node.ident) {
                 self.free_variables.insert(node.ident.clone());
-                node.ident = syn::Ident::new(&format!("{}__free", node.ident), node.ident.span());
             }
         }
 
-        for node in i.segments.iter_mut() {
-            self.visit_path_arguments_mut(&mut node.arguments);
+        for node in i.segments.iter() {
+            self.visit_path_arguments(&node.arguments);
         }
     }
 
-    fn visit_arm_mut(&mut self, i: &mut syn::Arm) {
+    fn visit_arm(&mut self, i: &syn::Arm) {
         self.current_scope.push();
-        syn::visit_mut::visit_arm_mut(self, i);
+        syn::visit::visit_arm(self, i);
         self.current_scope.pop();
     }
 
-    fn visit_field_pat_mut(&mut self, i: &mut syn::FieldPat) {
-        for it in &mut i.attrs {
-            self.visit_attribute_mut(it);
+    fn visit_field_pat(&mut self, i: &syn::FieldPat) {
+        for it in &i.attrs {
+            self.visit_attribute(it);
         }
-        self.visit_pat_mut(&mut i.pat);
+        self.visit_pat(&i.pat);
     }
 
-    fn visit_pat_ident_mut(&mut self, i: &mut syn::PatIdent) {
+    fn visit_pat_ident(&mut self, i: &syn::PatIdent) {
         self.current_scope.insert_term(i.ident.clone());
     }
 
-    fn visit_expr_call_mut(&mut self, i: &mut syn::ExprCall) {
-        if let syn::Expr::Path(path) = i.func.as_mut() {
+    fn visit_expr_call(&mut self, i: &syn::ExprCall) {
+        if let syn::Expr::Path(path) = &*i.func {
             if path.path.segments.len() == 1 {
                 // skip, don't emit a free variable, assume that it's a
                 // fn call and not a closure call; for closure calls, we
                 // require the user to manually capture it with a `let` binding
             } else {
-                syn::visit_mut::visit_expr_mut(self, &mut i.func);
+                syn::visit::visit_expr(self, &i.func);
             }
         } else {
-            syn::visit_mut::visit_expr_mut(self, &mut i.func);
+            syn::visit::visit_expr(self, &i.func);
         }
 
-        for arg in &mut i.args {
-            self.visit_expr_mut(arg);
-        }
-    }
-
-    fn visit_expr_method_call_mut(&mut self, i: &mut syn::ExprMethodCall) {
-        syn::visit_mut::visit_expr_mut(self, &mut i.receiver);
-        for arg in &mut i.args {
-            self.visit_expr_mut(arg);
+        for arg in &i.args {
+            self.visit_expr(arg);
         }
     }
 
-    fn visit_type_mut(&mut self, _: &mut syn::Type) {}
-
-    fn visit_expr_struct_mut(&mut self, node: &mut syn::ExprStruct) {
-        for it in &mut node.attrs {
-            self.visit_attribute_mut(it);
+    fn visit_expr_method_call(&mut self, i: &syn::ExprMethodCall) {
+        syn::visit::visit_expr(self, &i.receiver);
+        for arg in &i.args {
+            self.visit_expr(arg);
         }
-        if let Some(it) = &mut node.qself {
-            self.visit_qself_mut(it);
+    }
+
+    fn visit_type(&mut self, _: &syn::Type) {}
+
+    fn visit_expr_struct(&mut self, node: &syn::ExprStruct) {
+        for it in &node.attrs {
+            self.visit_attribute(it);
+        }
+        if let Some(it) = &node.qself {
+            self.visit_qself(it);
         }
         // No need to capture the struct path
         // self.visit_path(&node.path);
-        for el in syn::punctuated::Punctuated::pairs_mut(&mut node.fields) {
+        for el in syn::punctuated::Punctuated::pairs(&node.fields) {
             let it = el.into_value();
-            self.visit_expr_mut(&mut it.expr);
+            self.visit_expr(&it.expr);
         }
-        if let Some(it) = &mut node.rest {
-            self.visit_expr_mut(it);
+        if let Some(it) = &node.rest {
+            self.visit_expr(it);
         }
     }
 
-    fn visit_expr_field_mut(&mut self, i: &mut syn::ExprField) {
-        self.visit_expr_mut(&mut i.base);
+    fn visit_expr_field(&mut self, i: &syn::ExprField) {
+        self.visit_expr(&i.base);
     }
 
-    fn visit_macro_mut(&mut self, i: &mut syn::Macro) {
+    fn visit_macro(&mut self, i: &syn::Macro) {
         // TODO(shadaj): emit a warning if our guess at parsing fails
         match i.delimiter {
             syn::MacroDelimiter::Paren(_binding_0) => {
-                i.tokens = i
-                    .parse_body_with(
-                        syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
-                    )
-                    .ok()
-                    .map(|mut exprs| {
-                        for arg in &mut exprs {
-                            self.visit_expr_mut(arg);
-                        }
-                        exprs.to_token_stream()
-                    })
-                    .unwrap_or(i.tokens.clone());
+                i.parse_body_with(
+                    syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
+                )
+                .ok()
+                .into_iter()
+                .for_each(|exprs| {
+                    for arg in &exprs {
+                        self.visit_expr(arg);
+                    }
+                });
             }
             syn::MacroDelimiter::Brace(_binding_0) => {
-                i.tokens = i
-                    .parse_body_with(syn::Block::parse_within)
+                i.parse_body_with(syn::Block::parse_within)
                     .ok()
-                    .map(|mut stmts| {
-                        for stmt in &mut stmts {
-                            self.visit_stmt_mut(stmt);
+                    .into_iter()
+                    .for_each(|stmts| {
+                        for stmt in &stmts {
+                            self.visit_stmt(stmt);
                         }
-                        syn::punctuated::Punctuated::<syn::Stmt, syn::Token![;]>::from_iter(stmts)
-                            .to_token_stream()
-                    })
-                    .unwrap_or(i.tokens.clone());
+                    });
             }
             syn::MacroDelimiter::Bracket(_binding_0) => {
-                i.tokens = i
-                    .parse_body_with(
-                        syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
-                    )
-                    .ok()
-                    .map(|mut exprs| {
-                        for arg in &mut exprs {
-                            self.visit_expr_mut(arg);
-                        }
-                        exprs.to_token_stream()
-                    })
-                    .unwrap_or(i.tokens.clone());
+                i.parse_body_with(
+                    syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
+                )
+                .ok()
+                .into_iter()
+                .for_each(|exprs| {
+                    for arg in &exprs {
+                        self.visit_expr(arg);
+                    }
+                });
             }
         }
     }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local@macro_tokens.snap
@@ -8,19 +8,19 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x__free = {
+            let x = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
                 );
                 _vec_to_set
                     .push((
-                        "x__free".to_string(),
+                        "x".to_string(),
                         ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -28,21 +28,18 @@ fn main() {
                     ));
                 _out
             };
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                (x__free + 2) + (x__free + 2)
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "(x + 2) + (x + 2)";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x__free);
+                ::std::mem::forget(x);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
             }
-            #[allow(unreachable_code, unused_qualifications)]
-            { (x__free + 2) + (x__free + 2) }
+            #[allow(unreachable_code, unused_qualifications)] { (x + 2) + (x + 2) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local_block@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local_block@macro_tokens.snap
@@ -8,19 +8,19 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x__free = {
+            let x = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
                 );
                 _vec_to_set
                     .push((
-                        "x__free".to_string(),
+                        "x".to_string(),
                         ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -28,15 +28,13 @@ fn main() {
                     ));
                 _out
             };
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                { let _ = x__free + 2; let _ = x__free + 2; }
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "{ let _ = x + 2 ; let _ = x + 2 ; }";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x__free);
+                ::std::mem::forget(x);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
@@ -44,8 +42,8 @@ fn main() {
             #[allow(unreachable_code, unused_qualifications)]
             {
                 {
-                    let _ = x__free + 2;
-                    let _ = x__free + 2;
+                    let _ = x + 2;
+                    let _ = x + 2;
                 }
             }
         }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local_block_let@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local_block_let@macro_tokens.snap
@@ -8,19 +8,19 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x__free = {
+            let x = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
                 );
                 _vec_to_set
                     .push((
-                        "x__free".to_string(),
+                        "x".to_string(),
                         ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -28,15 +28,13 @@ fn main() {
                     ));
                 _out
             };
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                { let x = x__free + 2; let _ = x + 2; }
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "{ let x = x + 2 ; let _ = x + 2 ; }";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x__free);
+                ::std::mem::forget(x);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
@@ -44,7 +42,7 @@ fn main() {
             #[allow(unreachable_code, unused_qualifications)]
             {
                 {
-                    let x = x__free + 2;
+                    let x = x + 2;
                     let _ = x + 2;
                 }
             }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_in_macro@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_in_macro@macro_tokens.snap
@@ -8,19 +8,19 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x__free = {
+            let x = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
                 );
                 _vec_to_set
                     .push((
-                        "x__free".to_string(),
+                        "x".to_string(),
                         ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -28,20 +28,18 @@ fn main() {
                     ));
                 _out
             };
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                dbg!(x__free)
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "dbg ! (x)";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x__free);
+                ::std::mem::forget(x);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
             }
-            #[allow(unreachable_code, unused_qualifications)] { dbg!(x__free) }
+            #[allow(unreachable_code, unused_qualifications)] { dbg!(x) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_local@macro_tokens.snap
@@ -8,19 +8,19 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x__free = {
+            let x = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
                 );
                 _vec_to_set
                     .push((
-                        "x__free".to_string(),
+                        "x".to_string(),
                         ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -28,20 +28,18 @@ fn main() {
                     ));
                 _out
             };
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                x__free + 2
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "x + 2";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x__free);
+                ::std::mem::forget(x);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
             }
-            #[allow(unreachable_code, unused_qualifications)] { x__free + 2 }
+            #[allow(unreachable_code, unused_qualifications)] { x + 2 }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_local_mut@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_local_mut@macro_tokens.snap
@@ -8,19 +8,19 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x__free = {
+            let x = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
                 );
                 _vec_to_set
                     .push((
-                        "x__free".to_string(),
+                        "x".to_string(),
                         ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -28,20 +28,18 @@ fn main() {
                     ));
                 _out
             };
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                x__free += 2
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "x += 2";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x__free);
+                ::std::mem::forget(x);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
             }
-            #[allow(unreachable_code, unused_qualifications)] { x__free += 2 }
+            #[allow(unreachable_code, unused_qualifications)] { x += 2 }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__non_capture_enum_creation@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__non_capture_enum_creation@macro_tokens.snap
@@ -8,17 +8,15 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                Foo::Bar { x : 1 }
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "Foo :: Bar { x : 1 }";
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__non_capture_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__non_capture_local@macro_tokens.snap
@@ -8,17 +8,15 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                { let x = 1; x + 2 }
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "{ let x = 1 ; x + 2 }";
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__non_capture_struct_creation@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__non_capture_struct_creation@macro_tokens.snap
@@ -8,17 +8,15 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                Foo { x : 1 }
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "Foo { x : 1 }";
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__prelude_enum_variants@macro_tokens-2.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__prelude_enum_variants@macro_tokens-2.snap
@@ -8,17 +8,15 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                None
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "None";
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__prelude_enum_variants@macro_tokens-3.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__prelude_enum_variants@macro_tokens-3.snap
@@ -8,17 +8,15 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                Ok(1)
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "Ok (1)";
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__prelude_enum_variants@macro_tokens-4.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__prelude_enum_variants@macro_tokens-4.snap
@@ -8,17 +8,15 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                Err(1)
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "Err (1)";
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__prelude_enum_variants@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__prelude_enum_variants@macro_tokens.snap
@@ -8,17 +8,15 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                Some(1)
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "Some (1)";
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__simple@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__simple@macro_tokens.snap
@@ -8,17 +8,15 @@ fn main() {
             __stageleft_ctx: &_,
             set_mod: &mut String,
             set_crate_name: &mut &'static str,
-            set_tokens: &mut stageleft::internal::TokenStream,
+            set_tokens: &mut &'static str,
             _vec_to_set: &mut stageleft::internal::CaptureVec,
             run: bool|
         {
-            *set_mod = module_path!().to_string();
-            *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                .unwrap_or(env!("CARGO_PKG_NAME"));
-            *set_tokens = stageleft::internal::quote! {
-                1 + 2
-            };
             if !run {
+                *set_mod = module_path!().to_string();
+                *set_crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                *set_tokens = "1 + 2";
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }


### PR DESCRIPTION

Rust Analyzer seems to trip up on the input to the `q!(...)` macro being double-emitted, so we use environment variables to detect when we are being called from Rust Analyzer and work around this issue. The end result is that when code completing from syntactically valid code, the completions work!

Under the hood, this also tweaks the free variable analysis. Before, each free variable would be replaced in the body with an `__free` variant. Now, we use the same identifier as the original variable and use shadowing rules to introduce the unquoted value. This should reduce brittleness when the macro fails to identify a free variable that's used somewhere else.
