### PR TITLE
fix: restore ability to reference statics/consts in a quoted context

### DIFF
--- a/stageleft_macro/Cargo.toml
+++ b/stageleft_macro/Cargo.toml
@@ -19,6 +19,7 @@ syn = { version = "2.0.46", features = [
     "full",
     "parsing",
     "visit",
+    "visit-mut",
 ] }
 proc-macro2 = "1.0.74"
 proc-macro-crate = "1.0.0"

--- a/stageleft_macro/src/quote_impl/free_variable/mod.rs
+++ b/stageleft_macro/src/quote_impl/free_variable/mod.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, HashSet};
 
 mod prelude;
 use prelude::is_prelude;
+use quote::ToTokens;
 
 #[derive(Debug)]
 pub struct ScopeStack {
@@ -64,25 +65,25 @@ pub struct FreeVariableVisitor {
     pub current_scope: ScopeStack,
 }
 
-impl syn::visit::Visit<'_> for FreeVariableVisitor {
-    fn visit_expr_closure(&mut self, i: &syn::ExprClosure) {
+impl syn::visit_mut::VisitMut for FreeVariableVisitor {
+    fn visit_expr_closure_mut(&mut self, i: &mut syn::ExprClosure) {
         self.current_scope.push();
-        i.inputs.iter().for_each(|input| {
-            self.visit_pat(input);
+        i.inputs.iter_mut().for_each(|input| {
+            self.visit_pat_mut(input);
         });
 
-        syn::visit::visit_expr_closure(self, i);
+        syn::visit_mut::visit_expr_closure_mut(self, i);
 
         self.current_scope.pop();
     }
 
-    fn visit_item_fn(&mut self, i: &syn::ItemFn) {
+    fn visit_item_fn_mut(&mut self, i: &mut syn::ItemFn) {
         self.current_scope.push();
-        syn::visit::visit_item_fn(self, i);
+        syn::visit_mut::visit_item_fn_mut(self, i);
         self.current_scope.pop();
     }
 
-    fn visit_generic_param(&mut self, i: &syn::GenericParam) {
+    fn visit_generic_param_mut(&mut self, i: &mut syn::GenericParam) {
         match i {
             syn::GenericParam::Type(type_param) => {
                 self.current_scope.insert_type(type_param.ident.clone());
@@ -97,163 +98,174 @@ impl syn::visit::Visit<'_> for FreeVariableVisitor {
         }
     }
 
-    fn visit_block(&mut self, i: &syn::Block) {
+    fn visit_block_mut(&mut self, i: &mut syn::Block) {
         self.current_scope.push();
-        syn::visit::visit_block(self, i);
+        syn::visit_mut::visit_block_mut(self, i);
         self.current_scope.pop();
     }
 
-    fn visit_local(&mut self, i: &syn::Local) {
-        i.init.iter().for_each(|init| {
-            syn::visit::visit_local_init(self, init);
+    fn visit_local_mut(&mut self, i: &mut syn::Local) {
+        i.init.iter_mut().for_each(|init| {
+            syn::visit_mut::visit_local_init_mut(self, init);
         });
-        match &i.pat {
+
+        match &mut i.pat {
             syn::Pat::Ident(pat_ident) => {
                 self.current_scope.insert_term(pat_ident.ident.clone());
             }
             syn::Pat::Type(pat_type) => {
-                self.visit_pat(&pat_type.pat);
+                self.visit_pat_mut(&mut pat_type.pat);
             }
             syn::Pat::Wild(_) => {
                 // Do nothing
             }
             syn::Pat::Tuple(pat_tuple) => {
-                for el in &pat_tuple.elems {
-                    self.visit_pat(el);
+                for el in &mut pat_tuple.elems {
+                    self.visit_pat_mut(el);
                 }
             }
             _ => panic!("Local variables must be identifiers, got {:?}", i.pat),
         }
     }
 
-    fn visit_ident(&mut self, i: &proc_macro2::Ident) {
+    fn visit_ident_mut(&mut self, i: &mut proc_macro2::Ident) {
         if !self.current_scope.contains_term(i) {
             self.free_variables.insert(i.clone());
+            *i = syn::Ident::new(&format!("{}__free", i), i.span());
         }
     }
 
-    fn visit_lifetime(&mut self, i: &syn::Lifetime) {
+    fn visit_lifetime_mut(&mut self, i: &mut syn::Lifetime) {
         if !self.current_scope.contains_type(&i.ident) {
             self.free_variables.insert(i.ident.clone());
+            i.ident = syn::Ident::new(&format!("{}__free", i.ident), i.ident.span());
         }
     }
 
-    fn visit_path(&mut self, i: &syn::Path) {
+    fn visit_path_mut(&mut self, i: &mut syn::Path) {
         if i.leading_colon.is_none() && !is_prelude(&i.segments.first().unwrap().ident) {
             let one_segment = i.segments.len() == 1;
-            let node = i.segments.first().unwrap();
+            let node = i.segments.first_mut().unwrap();
             if one_segment && !self.current_scope.contains_term(&node.ident) {
                 self.free_variables.insert(node.ident.clone());
+                node.ident = syn::Ident::new(&format!("{}__free", node.ident), node.ident.span());
             }
         }
 
-        for node in i.segments.iter() {
-            self.visit_path_arguments(&node.arguments);
+        for node in i.segments.iter_mut() {
+            self.visit_path_arguments_mut(&mut node.arguments);
         }
     }
 
-    fn visit_arm(&mut self, i: &syn::Arm) {
+    fn visit_arm_mut(&mut self, i: &mut syn::Arm) {
         self.current_scope.push();
-        syn::visit::visit_arm(self, i);
+        syn::visit_mut::visit_arm_mut(self, i);
         self.current_scope.pop();
     }
 
-    fn visit_field_pat(&mut self, i: &syn::FieldPat) {
-        for it in &i.attrs {
-            self.visit_attribute(it);
+    fn visit_field_pat_mut(&mut self, i: &mut syn::FieldPat) {
+        for it in &mut i.attrs {
+            self.visit_attribute_mut(it);
         }
-        self.visit_pat(&i.pat);
+        self.visit_pat_mut(&mut i.pat);
     }
 
-    fn visit_pat_ident(&mut self, i: &syn::PatIdent) {
+    fn visit_pat_ident_mut(&mut self, i: &mut syn::PatIdent) {
         self.current_scope.insert_term(i.ident.clone());
     }
 
-    fn visit_expr_call(&mut self, i: &syn::ExprCall) {
-        if let syn::Expr::Path(path) = &*i.func {
+    fn visit_expr_call_mut(&mut self, i: &mut syn::ExprCall) {
+        if let syn::Expr::Path(path) = i.func.as_mut() {
             if path.path.segments.len() == 1 {
                 // skip, don't emit a free variable, assume that it's a
                 // fn call and not a closure call; for closure calls, we
                 // require the user to manually capture it with a `let` binding
             } else {
-                syn::visit::visit_expr(self, &i.func);
+                syn::visit_mut::visit_expr_mut(self, &mut i.func);
             }
         } else {
-            syn::visit::visit_expr(self, &i.func);
+            syn::visit_mut::visit_expr_mut(self, &mut i.func);
         }
 
-        for arg in &i.args {
-            self.visit_expr(arg);
-        }
-    }
-
-    fn visit_expr_method_call(&mut self, i: &syn::ExprMethodCall) {
-        syn::visit::visit_expr(self, &i.receiver);
-        for arg in &i.args {
-            self.visit_expr(arg);
+        for arg in &mut i.args {
+            self.visit_expr_mut(arg);
         }
     }
 
-    fn visit_type(&mut self, _: &syn::Type) {}
-
-    fn visit_expr_struct(&mut self, node: &syn::ExprStruct) {
-        for it in &node.attrs {
-            self.visit_attribute(it);
+    fn visit_expr_method_call_mut(&mut self, i: &mut syn::ExprMethodCall) {
+        syn::visit_mut::visit_expr_mut(self, &mut i.receiver);
+        for arg in &mut i.args {
+            self.visit_expr_mut(arg);
         }
-        if let Some(it) = &node.qself {
-            self.visit_qself(it);
+    }
+
+    fn visit_type_mut(&mut self, _: &mut syn::Type) {}
+
+    fn visit_expr_struct_mut(&mut self, node: &mut syn::ExprStruct) {
+        for it in &mut node.attrs {
+            self.visit_attribute_mut(it);
+        }
+        if let Some(it) = &mut node.qself {
+            self.visit_qself_mut(it);
         }
         // No need to capture the struct path
         // self.visit_path(&node.path);
-        for el in syn::punctuated::Punctuated::pairs(&node.fields) {
+        for el in syn::punctuated::Punctuated::pairs_mut(&mut node.fields) {
             let it = el.into_value();
-            self.visit_expr(&it.expr);
+            self.visit_expr_mut(&mut it.expr);
         }
-        if let Some(it) = &node.rest {
-            self.visit_expr(it);
+        if let Some(it) = &mut node.rest {
+            self.visit_expr_mut(it);
         }
     }
 
-    fn visit_expr_field(&mut self, i: &syn::ExprField) {
-        self.visit_expr(&i.base);
+    fn visit_expr_field_mut(&mut self, i: &mut syn::ExprField) {
+        self.visit_expr_mut(&mut i.base);
     }
 
-    fn visit_macro(&mut self, i: &syn::Macro) {
+    fn visit_macro_mut(&mut self, i: &mut syn::Macro) {
         // TODO(shadaj): emit a warning if our guess at parsing fails
         match i.delimiter {
             syn::MacroDelimiter::Paren(_binding_0) => {
-                i.parse_body_with(
-                    syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
-                )
-                .ok()
-                .into_iter()
-                .for_each(|exprs| {
-                    for arg in &exprs {
-                        self.visit_expr(arg);
-                    }
-                });
+                i.tokens = i
+                    .parse_body_with(
+                        syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
+                    )
+                    .ok()
+                    .map(|mut exprs| {
+                        for arg in &mut exprs {
+                            self.visit_expr_mut(arg);
+                        }
+                        exprs.to_token_stream()
+                    })
+                    .unwrap_or(i.tokens.clone());
             }
             syn::MacroDelimiter::Brace(_binding_0) => {
-                i.parse_body_with(syn::Block::parse_within)
+                i.tokens = i
+                    .parse_body_with(syn::Block::parse_within)
                     .ok()
-                    .into_iter()
-                    .for_each(|stmts| {
-                        for stmt in &stmts {
-                            self.visit_stmt(stmt);
+                    .map(|mut stmts| {
+                        for stmt in &mut stmts {
+                            self.visit_stmt_mut(stmt);
                         }
-                    });
+                        syn::punctuated::Punctuated::<syn::Stmt, syn::Token![;]>::from_iter(stmts)
+                            .to_token_stream()
+                    })
+                    .unwrap_or(i.tokens.clone());
             }
             syn::MacroDelimiter::Bracket(_binding_0) => {
-                i.parse_body_with(
-                    syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
-                )
-                .ok()
-                .into_iter()
-                .for_each(|exprs| {
-                    for arg in &exprs {
-                        self.visit_expr(arg);
-                    }
-                });
+                i.tokens = i
+                    .parse_body_with(
+                        syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
+                    )
+                    .ok()
+                    .map(|mut exprs| {
+                        for arg in &mut exprs {
+                            self.visit_expr_mut(arg);
+                        }
+                        exprs.to_token_stream()
+                    })
+                    .unwrap_or(i.tokens.clone());
             }
         }
     }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local@macro_tokens.snap
@@ -6,7 +6,7 @@ fn main() {
     {
         move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x = {
+            let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
@@ -14,7 +14,7 @@ fn main() {
                 __output
                     .captures
                     .push(::stageleft::internal::Capture {
-                        ident: "x",
+                        ident: "x__free",
                         tokens: ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -26,14 +26,15 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
-                __output.tokens = "(x + 2) + (x + 2)";
+                __output.tokens = "(x__free + 2) + (x__free + 2)";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x);
+                ::std::mem::forget(x__free);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
             }
-            #[allow(unreachable_code, unused_qualifications)] { (x + 2) + (x + 2) }
+            #[allow(unreachable_code, unused_qualifications)]
+            { (x__free + 2) + (x__free + 2) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local_block@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local_block@macro_tokens.snap
@@ -6,7 +6,7 @@ fn main() {
     {
         move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x = {
+            let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
@@ -14,7 +14,7 @@ fn main() {
                 __output
                     .captures
                     .push(::stageleft::internal::Capture {
-                        ident: "x",
+                        ident: "x__free",
                         tokens: ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -26,9 +26,9 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
-                __output.tokens = "{ let _ = x + 2 ; let _ = x + 2 ; }";
+                __output.tokens = "{ let _ = x__free + 2 ; let _ = x__free + 2 ; }";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x);
+                ::std::mem::forget(x__free);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
@@ -36,8 +36,8 @@ fn main() {
             #[allow(unreachable_code, unused_qualifications)]
             {
                 {
-                    let _ = x + 2;
-                    let _ = x + 2;
+                    let _ = x__free + 2;
+                    let _ = x__free + 2;
                 }
             }
         }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local_block_let@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_copy_local_block_let@macro_tokens.snap
@@ -6,7 +6,7 @@ fn main() {
     {
         move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x = {
+            let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
@@ -14,7 +14,7 @@ fn main() {
                 __output
                     .captures
                     .push(::stageleft::internal::Capture {
-                        ident: "x",
+                        ident: "x__free",
                         tokens: ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -26,9 +26,9 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
-                __output.tokens = "{ let x = x + 2 ; let _ = x + 2 ; }";
+                __output.tokens = "{ let x = x__free + 2 ; let _ = x + 2 ; }";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x);
+                ::std::mem::forget(x__free);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
@@ -36,7 +36,7 @@ fn main() {
             #[allow(unreachable_code, unused_qualifications)]
             {
                 {
-                    let x = x + 2;
+                    let x = x__free + 2;
                     let _ = x + 2;
                 }
             }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_in_macro@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_in_macro@macro_tokens.snap
@@ -6,7 +6,7 @@ fn main() {
     {
         move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x = {
+            let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
@@ -14,7 +14,7 @@ fn main() {
                 __output
                     .captures
                     .push(::stageleft::internal::Capture {
-                        ident: "x",
+                        ident: "x__free",
                         tokens: ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -26,14 +26,14 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
-                __output.tokens = "dbg ! (x)";
+                __output.tokens = "dbg ! (x__free)";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x);
+                ::std::mem::forget(x__free);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
             }
-            #[allow(unreachable_code, unused_qualifications)] { dbg!(x) }
+            #[allow(unreachable_code, unused_qualifications)] { dbg!(x__free) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_local@macro_tokens.snap
@@ -6,7 +6,7 @@ fn main() {
     {
         move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x = {
+            let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
@@ -14,7 +14,7 @@ fn main() {
                 __output
                     .captures
                     .push(::stageleft::internal::Capture {
-                        ident: "x",
+                        ident: "x__free",
                         tokens: ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -26,14 +26,14 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
-                __output.tokens = "x + 2";
+                __output.tokens = "x__free + 2";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x);
+                ::std::mem::forget(x__free);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
             }
-            #[allow(unreachable_code, unused_qualifications)] { x + 2 }
+            #[allow(unreachable_code, unused_qualifications)] { x__free + 2 }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_local_mut@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/stageleft_macro__quote_impl__tests__capture_local_mut@macro_tokens.snap
@@ -6,7 +6,7 @@ fn main() {
     {
         move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
-            let x = {
+            let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
                     &x,
                     __stageleft_ctx,
@@ -14,7 +14,7 @@ fn main() {
                 __output
                     .captures
                     .push(::stageleft::internal::Capture {
-                        ident: "x",
+                        ident: "x__free",
                         tokens: ::stageleft::runtime_support::FreeVariableWithContext::to_tokens(
                             x,
                             __stageleft_ctx,
@@ -26,14 +26,14 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
-                __output.tokens = "x += 2";
+                __output.tokens = "x__free += 2";
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
-                ::std::mem::forget(x);
+                ::std::mem::forget(x__free);
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }
             }
-            #[allow(unreachable_code, unused_qualifications)] { x += 2 }
+            #[allow(unreachable_code, unused_qualifications)] { x__free += 2 }
         }
     }
 }

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -6,6 +6,13 @@ use stageleft::{BorrowBounds, IntoQuotedOnce, Quoted, RuntimeData, q};
 pub(crate) mod features;
 pub(crate) mod submodule;
 
+static GLOBAL_VAR: i32 = 42;
+
+#[stageleft::entry]
+pub fn using_global_var(_ctx: BorrowBounds<'_>) -> impl Quoted<i32> {
+    q!(GLOBAL_VAR)
+}
+
 #[stageleft::entry]
 pub fn using_rand(_ctx: BorrowBounds<'_>) -> impl Quoted<i32> {
     q!(rand::random::<i32>())


### PR DESCRIPTION

I forgot that the `__free` suffix helps to handle references to statics, so restore that behavior.
