### PR TITLE
fix: convert `crate`, `self`, and `super` references into absolute paths

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -1,22 +1,22 @@
 use core::panic;
 use std::marker::PhantomData;
 
-use internal::{QuoteTokens, QuotedOutput};
+use internal::QuotedOutput;
 use proc_macro_crate::FoundCrate;
 use proc_macro2::Span;
 use quote::quote;
 
+pub use stageleft_macro::{entry, q, quse_fn, top_level_mod};
+pub use type_name::{add_private_reexport, quote_type};
+
 #[doc(hidden)]
 pub mod internal {
+    use crate::runtime_support::QuoteTokens;
     pub use ctor;
     pub use proc_macro2::{Span, TokenStream};
     pub use quote::quote;
-    pub use {proc_macro_crate, proc_macro2, syn};
 
-    pub struct QuoteTokens {
-        pub prelude: Option<TokenStream>,
-        pub expr: Option<TokenStream>,
-    }
+    pub use {proc_macro_crate, proc_macro2, syn};
 
     pub struct Capture {
         pub ident: &'static str,
@@ -31,15 +31,12 @@ pub mod internal {
     }
 }
 
-pub use stageleft_macro::{entry, q, quse_fn, top_level_mod};
-
+mod rewrite_paths;
 pub mod runtime_support;
-use runtime_support::FreeVariableWithContext;
-
-use crate::runtime_support::get_final_crate_name;
-
 mod type_name;
-pub use type_name::{add_private_reexport, quote_type};
+
+use runtime_support::{FreeVariableWithContext, QuoteTokens, get_final_crate_name};
+use syn::visit_mut::VisitMut;
 
 #[cfg(windows)]
 #[macro_export]
@@ -393,7 +390,15 @@ impl<T, Ctx, F: for<'b> FnOnce(&'b Ctx, &mut QuotedOutput) -> T> FreeVariableWit
             })
         };
 
-        let expr: syn::Expr = syn::parse_str(output.tokens).unwrap();
+        let mut expr: syn::Expr = syn::parse_str(output.tokens).unwrap();
+        rewrite_paths::RewritePaths {
+            crate_root_path: syn::parse_quote!(#final_crate_root::__staged),
+            module_path: module_path
+                .clone()
+                .map(|module_path| syn::parse_quote!(#final_crate_root::__staged::#module_path)),
+        }
+        .visit_expr_mut(&mut expr);
+
         let with_env = if let Some(module_path) = module_path {
             quote!({
                 use #final_crate_root::__staged::__deps::*;

--- a/stageleft/src/rewrite_paths.rs
+++ b/stageleft/src/rewrite_paths.rs
@@ -1,0 +1,46 @@
+use syn::{Path, visit_mut::VisitMut};
+
+pub struct RewritePaths {
+    pub(super) crate_root_path: Path,
+    pub(super) module_path: Option<Path>,
+}
+
+impl VisitMut for RewritePaths {
+    fn visit_path_mut(&mut self, path: &mut Path) {
+        if path.segments.first().is_some_and(|s| s.ident == "crate") {
+            let path_tail = path.segments.iter().skip(1);
+            path.segments = self
+                .crate_root_path
+                .segments
+                .iter()
+                .chain(path_tail)
+                .cloned()
+                .collect();
+        } else if let Some(module_path) = &self.module_path {
+            let mut path_skip_count = 0;
+            let mut module_skip_end_count = 0;
+
+            for segment in path.segments.iter() {
+                if segment.ident == "self" {
+                    path_skip_count += 1;
+                } else if segment.ident == "super" {
+                    path_skip_count += 1;
+                    module_skip_end_count += 1;
+                } else {
+                    break;
+                }
+            }
+
+            if path_skip_count > 0 {
+                let path_tail = path.segments.iter().skip(path_skip_count);
+                path.segments = module_path
+                    .segments
+                    .iter()
+                    .take(module_path.segments.len() - module_skip_end_count)
+                    .chain(path_tail)
+                    .cloned()
+                    .collect();
+            }
+        }
+    }
+}

--- a/stageleft/src/runtime_support.rs
+++ b/stageleft/src/runtime_support.rs
@@ -5,7 +5,12 @@ use std::mem::MaybeUninit;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 
-use crate::{QuotedWithContext, internal::QuoteTokens};
+use crate::QuotedWithContext;
+
+pub struct QuoteTokens {
+    pub prelude: Option<TokenStream>,
+    pub expr: Option<TokenStream>,
+}
 
 pub fn get_final_crate_name(crate_name: &str) -> TokenStream {
     let final_crate = proc_macro_crate::crate_name(crate_name)

--- a/stageleft_macro/src/quote_impl/free_variable/mod.rs
+++ b/stageleft_macro/src/quote_impl/free_variable/mod.rs
@@ -174,24 +174,6 @@ impl syn::visit_mut::VisitMut for FreeVariableVisitor {
         self.current_scope.insert_term(i.ident.clone());
     }
 
-    fn visit_expr_call_mut(&mut self, i: &mut syn::ExprCall) {
-        if let syn::Expr::Path(path) = i.func.as_mut() {
-            if path.path.segments.len() == 1 {
-                // skip, don't emit a free variable, assume that it's a
-                // fn call and not a closure call; for closure calls, we
-                // require the user to manually capture it with a `let` binding
-            } else {
-                syn::visit_mut::visit_expr_mut(self, &mut i.func);
-            }
-        } else {
-            syn::visit_mut::visit_expr_mut(self, &mut i.func);
-        }
-
-        for arg in &mut i.args {
-            self.visit_expr_mut(arg);
-        }
-    }
-
     fn visit_expr_method_call_mut(&mut self, i: &mut syn::ExprMethodCall) {
         syn::visit_mut::visit_expr_mut(self, &mut i.receiver);
         for arg in &mut i.args {

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -52,13 +52,8 @@ fn my_top_level_function() -> bool {
 }
 
 #[stageleft::entry]
-fn crate_paths<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
+pub fn crate_paths<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
     q!(crate::my_top_level_function())
-}
-
-#[stageleft::entry]
-fn local_paths<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
-    q!(my_top_level_function())
 }
 
 #[stageleft::entry]
@@ -100,7 +95,17 @@ mod tests {
 
     #[test]
     fn test_local_paths() {
-        assert!(local_paths!());
+        assert!(submodule::self_path!());
+    }
+
+    #[test]
+    fn test_super_paths() {
+        assert!(submodule::subsubmodule::super_path!() == 42);
+    }
+
+    #[test]
+    fn test_self_super_paths() {
+        assert!(submodule::subsubmodule::self_super_path!() == 42);
     }
 
     #[test]

--- a/stageleft_test/src/submodule.rs
+++ b/stageleft_test/src/submodule.rs
@@ -24,3 +24,26 @@ pub fn private_struct(_ctx: BorrowBounds<'_>) -> impl Quoted<u32> {
 pub fn public_struct(_ctx: BorrowBounds<'_>) -> impl Quoted<PublicStruct> {
     q!(PublicStruct { a: 1 })
 }
+
+fn my_local_function() -> bool {
+    true
+}
+
+#[stageleft::entry]
+pub fn self_path<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
+    q!(self::my_local_function())
+}
+
+pub mod subsubmodule {
+    use stageleft::{BorrowBounds, Quoted, q};
+
+    #[stageleft::entry]
+    pub fn super_path<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, i32> {
+        q!(super::super::GLOBAL_VAR)
+    }
+
+    #[stageleft::entry]
+    pub fn self_super_path<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, i32> {
+        q!(self::super::super::GLOBAL_VAR)
+    }
+}

--- a/stageleft_test_downstream/src/lib.rs
+++ b/stageleft_test_downstream/src/lib.rs
@@ -1,9 +1,14 @@
 #[cfg(test)]
 mod tests {
-    use stageleft_test::using_rand;
+    use stageleft_test::{crate_paths, using_rand};
 
     #[test]
     fn test_quoted_using_dependency() {
         let _ = using_rand!();
+    }
+
+    #[test]
+    fn test_quoted_using_crate() {
+        let _ = crate_paths!();
     }
 }

--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -143,6 +143,16 @@ impl VisitMut for GenFinalPubVistor {
         // variant fields do not have visibility modifiers
     }
 
+    fn visit_item_static_mut(&mut self, i: &mut syn::ItemStatic) {
+        i.vis = parse_quote!(pub);
+        syn::visit_mut::visit_item_static_mut(self, i);
+    }
+
+    fn visit_item_const_mut(&mut self, i: &mut syn::ItemConst) {
+        i.vis = parse_quote!(pub);
+        syn::visit_mut::visit_item_const_mut(self, i);
+    }
+
     fn visit_item_struct_mut(&mut self, i: &mut syn::ItemStruct) {
         i.vis = parse_quote!(pub);
         syn::visit_mut::visit_item_struct_mut(self, i);


### PR DESCRIPTION

Fixes #4
