### PR TITLE
feat(stageleft)!: remove `stageleft_devel`, make macro entrypoints opt-in via a feature

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -16,6 +16,7 @@ pub mod internal {
     pub use proc_macro2::{Span, TokenStream};
     pub use quote::quote;
 
+    pub use crate::type_name::add_crate_with_staged;
     pub use {proc_macro_crate, proc_macro2, syn};
 
     pub struct Capture {
@@ -86,14 +87,13 @@ macro_rules! stageleft_no_entry_crate {
             reason = "generated code"
         )]
         pub mod __staged {
-            #[cfg(not(feature = "stageleft_devel"))]
+            #[cfg(any(feature = "stageleft_macro_entrypoint", stageleft_trybuild))]
             include!(concat!(
                 env!("OUT_DIR"),
                 $crate::PATH_SEPARATOR!(),
                 "lib_pub.rs"
             ));
 
-            #[cfg(not(feature = "stageleft_devel"))]
             include!(concat!(
                 env!("OUT_DIR"),
                 $crate::PATH_SEPARATOR!(),

--- a/stageleft/src/type_name.rs
+++ b/stageleft/src/type_name.rs
@@ -27,6 +27,8 @@ static PRIVATE_REEXPORTS: ReexportsSet = LazyLock::new(|| {
     ])
 });
 
+static CRATES_WITH_STAGED: RwLock<Vec<&'static str>> = RwLock::new(Vec::new());
+
 /// Adds a private module re-export transformation to the type quoting system.
 ///
 /// Sometimes, the [`quote_type`] function may produce an uncompilable reference to a
@@ -49,6 +51,14 @@ static PRIVATE_REEXPORTS: ReexportsSet = LazyLock::new(|| {
 pub fn add_private_reexport(from: Vec<&'static str>, to: Vec<&'static str>) {
     let mut transformations = PRIVATE_REEXPORTS.write().unwrap();
     transformations.push((from, to));
+}
+
+#[doc(hidden)]
+/// Internal API that marks a crate which has an `__staged` companion module to resolve
+/// symbols in quoted code.
+pub fn add_crate_with_staged(name: &'static str) {
+    let mut crates = CRATES_WITH_STAGED.write().unwrap();
+    crates.push(name);
 }
 
 struct RewritePrivateReexports {
@@ -97,6 +107,24 @@ impl VisitMut for RewritePrivateReexports {
     }
 }
 
+struct RewriteCrateWithStaged;
+
+impl VisitMut for RewriteCrateWithStaged {
+    fn visit_path_mut(&mut self, i: &mut syn::Path) {
+        if let Some(first_segment) = i.segments.first_mut() {
+            let crates = CRATES_WITH_STAGED.read().unwrap();
+
+            if crates.contains(&first_segment.ident.to_string().as_str())
+                && i.segments.get(1).is_none_or(|s| s.ident != "__staged")
+            {
+                i.segments.insert(1, parse_quote!(__staged));
+            }
+        }
+
+        syn::visit_mut::visit_path_mut(self, i);
+    }
+}
+
 struct ElimClosureToInfer;
 
 impl VisitMut for ElimClosureToInfer {
@@ -130,11 +158,12 @@ impl VisitMut for ElimClosureToInfer {
 pub fn quote_type<T>() -> syn::Type {
     let name = std::any::type_name::<T>().replace("{{closure}}", "CLOSURE_TO_INFER");
     let mut t_type: syn::Type = syn::parse_str(&name).unwrap_or_else(|_| {
-        panic!("Could not parse type name: {}", name);
+        panic!("Could not parse type name: {name}");
     });
     let mapping = super::runtime_support::MACRO_TO_CRATE.with(|m| m.borrow().clone());
     ElimClosureToInfer.visit_type_mut(&mut t_type);
     RewritePrivateReexports { mapping }.visit_type_mut(&mut t_type);
+    RewriteCrateWithStaged.visit_type_mut(&mut t_type);
 
     t_type
 }

--- a/stageleft_macro/src/quote_impl/free_variable/mod.rs
+++ b/stageleft_macro/src/quote_impl/free_variable/mod.rs
@@ -131,7 +131,7 @@ impl syn::visit_mut::VisitMut for FreeVariableVisitor {
     fn visit_ident_mut(&mut self, i: &mut proc_macro2::Ident) {
         if !self.current_scope.contains_term(i) {
             self.free_variables.insert(i.clone());
-            *i = syn::Ident::new(&format!("{}__free", i), i.span());
+            *i = syn::Ident::new(&format!("{i}__free"), i.span());
         }
     }
 

--- a/stageleft_macro/src/quote_impl/mod.rs
+++ b/stageleft_macro/src/quote_impl/mod.rs
@@ -18,7 +18,7 @@ pub fn q_impl(root: TokenStream, toks: proc_macro2::TokenStream) -> TokenStream 
     let unitialized_free_variables = visitor.free_variables.iter().map(|i| {
         let i_without_span = syn::Ident::new(&i.to_string(), Span::call_site());
 
-        let ident_shadow_str = format!("{}__free", i);
+        let ident_shadow_str = format!("{i}__free");
         let i_shadow_ident = syn::Ident::new(&ident_shadow_str, Span::call_site());
 
         quote!(
@@ -35,7 +35,7 @@ pub fn q_impl(root: TokenStream, toks: proc_macro2::TokenStream) -> TokenStream 
     });
 
     let uninit_forgets = visitor.free_variables.iter().map(|i| {
-        let i_shadow_ident = syn::Ident::new(&format!("{}__free", i), Span::call_site());
+        let i_shadow_ident = syn::Ident::new(&format!("{i}__free"), Span::call_site());
 
         quote!(
             #[allow(unused, non_upper_case_globals, non_snake_case)]

--- a/stageleft_test/Cargo.toml
+++ b/stageleft_test/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2024"
 release = false
 
 [features]
+default = ["stageleft_macro_entrypoint"]
+stageleft_macro_entrypoint = []
 test_feature = []
 
 [dependencies]


### PR DESCRIPTION

Previously, we defaulted to assume that there may be macro entrypoints, and so would always compile an updated `__staged` module whenever building any crate with quoted code. This flips the default, so we do not compile `__staged` by default, ans instead only do it if the compiler is invoked with `--cfg stageleft_trybuild` (for trybuild-style compilation in Hydro), or with the `stageleft_macro_entrypoint` feature enabled (for macro entrypoints).

The downstream impact of this is that in workspaces that do not have any macro entrypoints (such as Hydro), we skip compiling `__staged` in stage 0. This also dramatically reduces thrashing in Rust Analyzer, since we are not re-generating new Rust sources on each edit.

As part of the rewrite, we also simplify the logic of rewriting types and paths to use the `__staged` module. Now, all crates with quoted code register themselves in a constructor, so that we know to rewrite any references to types inside them.

This is a breaking change, since it flips the defaults for macro entrypoints.
