### PR TITLE
fix(stageleft_tool): re-run build scripts when trybuild mode changes

### DIFF
--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -518,6 +518,7 @@ macro_rules! gen_final {
         println!("cargo::rustc-cfg=stageleft_runtime");
 
         println!("cargo::rerun-if-changed=build.rs");
+        println!("cargo::rerun-if-env-changed=STAGELEFT_TRYBUILD_BUILD_STAGED");
 
         #[allow(
             unexpected_cfgs,


### PR DESCRIPTION

Cache needs to be invalidating when changing this, for example when manually setting in Rust Analyzer.
