### PR TITLE
fix(stageleft): process rewrites before`__deps` rewrites

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -16,7 +16,7 @@ pub mod internal {
     pub use proc_macro2::{Span, TokenStream};
     pub use quote::quote;
 
-    pub use crate::type_name::add_crate_with_staged;
+    pub use crate::type_name::{add_crate_with_staged, add_deps_reexport};
     pub use {proc_macro_crate, proc_macro2, syn};
 
     pub struct Capture {

--- a/stageleft/src/type_name.rs
+++ b/stageleft/src/type_name.rs
@@ -45,12 +45,19 @@ static PRIVATE_REEXPORTS: ReexportsSet = LazyLock::new(|| {
             vec!["std".into(), "vec".into()],
         ),
         (
+            vec!["std".into(), "io".into(), "error".into()],
+            vec!["std".into(), "io".into()],
+        ),
+        (
             vec!["tokio".into(), "time".into(), "instant".into()],
             vec!["tokio".into(), "time".into()],
         ),
         (vec!["bytes".into(), "bytes".into()], vec!["bytes".into()]),
+        (vec!["bytes".into(), "bytes_mut".into()], vec!["bytes".into()]),
     ])
 });
+
+static DEPS_REEXPORTS: RwLock<Vec<(Vec<String>, Vec<String>)>> = RwLock::new(vec![]);
 
 static CRATES_WITH_STAGED: RwLock<Vec<String>> = RwLock::new(Vec::new());
 
@@ -81,6 +88,14 @@ pub fn add_private_reexport(from: Vec<impl Into<String>>, to: Vec<impl Into<Stri
     ));
 }
 
+pub fn add_deps_reexport(from: Vec<impl Into<String>>, to: Vec<impl Into<String>>) {
+    let mut transformations = DEPS_REEXPORTS.write().unwrap();
+    transformations.push((
+        from.into_iter().map(Into::into).collect(),
+        to.into_iter().map(Into::into).collect(),
+    ));
+}
+
 #[doc(hidden)]
 /// Internal API that marks a crate which has an `__staged` companion module to resolve
 /// symbols in quoted code.
@@ -96,7 +111,8 @@ struct RewritePrivateReexports {
 impl VisitMut for RewritePrivateReexports {
     fn visit_path_mut(&mut self, i: &mut syn::Path) {
         let transformations = PRIVATE_REEXPORTS.read().unwrap();
-        for (from, to) in transformations.iter() {
+        let deps_transformations = DEPS_REEXPORTS.read().unwrap();
+        for (from, to) in transformations.iter() .chain(deps_transformations.iter()) {
             #[expect(clippy::cmp_owned, reason = "buggy lint for syn::Ident::to_string")]
             if i.segments.len() >= from.len()
                 && from

--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -411,7 +411,7 @@ fn gen_deps_module(stageleft_name: syn::Ident, manifest_path: &Path) -> syn::Ite
         .iter()
         .map(|name| {
             parse_quote! {
-                #stageleft_name::add_private_reexport(
+                #stageleft_name::internal::add_deps_reexport(
                     vec![#name],
                     vec![
                         option_env!("STAGELEFT_FINAL_CRATE_NAME").unwrap_or(env!("CARGO_PKG_NAME"))


### PR DESCRIPTION

Depending on the order in which `ctor`s are run, we can end up rewriting to use `__deps` before rewriting a private alias. We know separate these into two lists of rewrites, so we always process aliases first.

Also adds some missing rewrites found in Hydro.
