### PR TITLE
fix: ensure `stageleft_tool` uses aliased names for dependencies

### DIFF
--- a/stageleft_test/Cargo.toml
+++ b/stageleft_test/Cargo.toml
@@ -16,7 +16,7 @@ test_feature = []
 stageleft = { path = "../stageleft", version = "^0.9.5" }
 stageleft_test_macro = { path = "../stageleft_test_macro" }
 
-rand = { version = "0.9.0", features = ["thread_rng"] }
+rand_alias = { package = "rand", version = "0.9.0", features = ["thread_rng"] }
 
 [build-dependencies]
 stageleft_tool = { path = "../stageleft_tool", version = "^0.9.5" }

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -15,7 +15,7 @@ pub fn using_global_var(_ctx: BorrowBounds<'_>) -> impl Quoted<i32> {
 
 #[stageleft::entry]
 pub fn using_rand(_ctx: BorrowBounds<'_>) -> impl Quoted<i32> {
-    q!(rand::random::<i32>())
+    q!(rand_alias::random::<i32>())
 }
 
 #[stageleft::entry]

--- a/stageleft_test_macro/Cargo.toml
+++ b/stageleft_test_macro/Cargo.toml
@@ -16,7 +16,8 @@ path = "../stageleft_test/src/lib.rs"
 
 [dependencies]
 stageleft = { path = "../stageleft", version = "^0.9.5" }
-rand = { version = "0.9.0", features = ["thread_rng"] }
+
+rand_alias = { package = "rand", version = "0.9.0", features = ["thread_rng"] }
 
 [build-dependencies]
 stageleft_tool = { path = "../stageleft_tool", version = "^0.9.5" }

--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -388,12 +388,10 @@ fn gen_deps_module(stageleft_name: syn::Ident, manifest_path: &Path) -> syn::Ite
         .unwrap()
         .iter()
         .filter(|(_, v)| !v.get("optional").and_then(|o| o.as_bool()).unwrap_or(false))
-        .map(|(name, v)| {
-            v.get("package")
-                .and_then(|p| p.as_str())
-                .unwrap_or(name)
-                .to_string()
-                .replace('-', "_")
+        .map(|(name, _v)| {
+            // We want the LHS renamed name, not the actual package name inside `_v.get("package")`.
+            // `foo_alias = { package = "foo", ... }` -> we want `use foo_alias;`.
+            name.replace('-', "_")
         })
         .collect::<Vec<_>>();
 
@@ -495,7 +493,7 @@ pub fn gen_staged_deps() {
         panic!("Expected stageleft {main_pkg_name} package to be present in `Cargo.toml`")
     });
     let stageleft_name = match stageleft_crate {
-        proc_macro_crate::FoundCrate::Itself => syn::Ident::new("stageleft", Span::call_site()),
+        proc_macro_crate::FoundCrate::Itself => syn::Ident::new(main_pkg_name, Span::call_site()),
         proc_macro_crate::FoundCrate::Name(name) => syn::Ident::new(&name, Span::call_site()),
     };
 


### PR DESCRIPTION
This PR fixes how stageleft_tool handles dependency names to use aliased names instead of the original package names. The issue was that the code was extracting the actual package name from the dependency specification rather than using the alias specified in the Cargo.toml.

The code
```rust
v.get("package")
    .and_then(|p| p.as_str())
    .unwrap_or(name)
    .to_string()
    .replace('-', "_")
```
From `proc-macro-crate` actually gets the _original_ name, rather than the alias. Confusingly, their source code constructs a map `alias -> real` but then reverses it later `real -> alias` when it actually uses it.

Will see if I can add a test

Also fixes a left-behind issue with hardcoded `"stageleft"` that should've been fixed in #27