### PR TITLE
fix(stageleft_tool): properly handle exported macros when generating `__staged` module

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -83,6 +83,7 @@ macro_rules! stageleft_no_entry_crate {
             unused,
             ambiguous_glob_reexports,
             unexpected_cfgs,
+            mismatched_lifetime_syntaxes,
             clippy::suspicious_else_formatting,
             clippy::type_complexity,
             reason = "generated code"

--- a/stageleft/src/type_name.rs
+++ b/stageleft/src/type_name.rs
@@ -53,7 +53,10 @@ static PRIVATE_REEXPORTS: ReexportsSet = LazyLock::new(|| {
             vec!["tokio".into(), "time".into()],
         ),
         (vec!["bytes".into(), "bytes".into()], vec!["bytes".into()]),
-        (vec!["bytes".into(), "bytes_mut".into()], vec!["bytes".into()]),
+        (
+            vec!["bytes".into(), "bytes_mut".into()],
+            vec!["bytes".into()],
+        ),
     ])
 });
 
@@ -112,7 +115,7 @@ impl VisitMut for RewritePrivateReexports {
     fn visit_path_mut(&mut self, i: &mut syn::Path) {
         let transformations = PRIVATE_REEXPORTS.read().unwrap();
         let deps_transformations = DEPS_REEXPORTS.read().unwrap();
-        for (from, to) in transformations.iter() .chain(deps_transformations.iter()) {
+        for (from, to) in transformations.iter().chain(deps_transformations.iter()) {
             #[expect(clippy::cmp_owned, reason = "buggy lint for syn::Ident::to_string")]
             if i.segments.len() >= from.len()
                 && from
@@ -173,17 +176,16 @@ struct ElimClosureToInfer;
 
 impl VisitMut for ElimClosureToInfer {
     fn visit_type_mut(&mut self, i: &mut syn::Type) {
-        if let syn::Type::Path(p) = i {
-            if p.path
+        if let syn::Type::Path(p) = i
+            && p.path
                 .segments
                 .iter()
                 .any(|s| s.ident == "CLOSURE_TO_INFER")
-            {
-                *i = syn::Type::Infer(TypeInfer {
-                    underscore_token: Default::default(),
-                });
-                return;
-            }
+        {
+            *i = syn::Type::Infer(TypeInfer {
+                underscore_token: Default::default(),
+            });
+            return;
         }
 
         syn::visit_mut::visit_type_mut(self, i);

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -9,17 +9,21 @@ pub(crate) mod submodule;
 static GLOBAL_VAR: i32 = 42;
 
 #[stageleft::entry]
-pub fn using_global_var(_ctx: BorrowBounds<'_>) -> impl Quoted<i32> {
+pub fn using_global_var(_ctx: BorrowBounds<'_>) -> impl Quoted<'_, i32> {
     q!(GLOBAL_VAR)
 }
 
 #[stageleft::entry]
-pub fn using_rand(_ctx: BorrowBounds<'_>) -> impl Quoted<i32> {
+pub fn using_rand(_ctx: BorrowBounds<'_>) -> impl Quoted<'_, i32> {
     q!(rand::random::<i32>())
 }
 
 #[stageleft::entry]
-fn raise_to_power(_ctx: BorrowBounds<'_>, value: RuntimeData<i32>, power: u32) -> impl Quoted<i32> {
+fn raise_to_power(
+    _ctx: BorrowBounds<'_>,
+    value: RuntimeData<i32>,
+    power: u32,
+) -> impl Quoted<'_, i32> {
     if power == 1 {
         q!(value).boxed()
     } else if power % 2 == 0 {

--- a/stageleft_test/src/submodule.rs
+++ b/stageleft_test/src/submodule.rs
@@ -13,7 +13,7 @@ pub struct PublicStruct {
 }
 
 #[stageleft::entry]
-pub fn private_struct(_ctx: BorrowBounds<'_>) -> impl Quoted<u32> {
+pub fn private_struct(_ctx: BorrowBounds<'_>) -> impl Quoted<'_, u32> {
     q!({
         let my_struct = PrivateStruct { a: 1 };
         my_struct.a
@@ -21,7 +21,7 @@ pub fn private_struct(_ctx: BorrowBounds<'_>) -> impl Quoted<u32> {
 }
 
 #[stageleft::entry]
-pub fn public_struct(_ctx: BorrowBounds<'_>) -> impl Quoted<PublicStruct> {
+pub fn public_struct(_ctx: BorrowBounds<'_>) -> impl Quoted<'_, PublicStruct> {
     q!(PublicStruct { a: 1 })
 }
 


### PR DESCRIPTION

Previously, we would copy-paste the macro definition as-is, which would cause two macros to be exported to the top level with the same name. Now, we do not emit the declaration in `__staged` but generate a `pub use` to make sure relative imports work inside `__staged`.
