### PR TITLE
feat(stageleft_tool)!: handle test-mode staging with an environment variable

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -343,9 +343,8 @@ impl<'a, T, F: QuotedWithContext<'a, T, ()>> Quoted<'a, T> for F {}
 
 fn stageleft_root() -> syn::Ident {
     let pkg_name = env!("CARGO_PKG_NAME");
-    let stageleft_crate = proc_macro_crate::crate_name(pkg_name).unwrap_or_else(|_| {
-        panic!("Expected stageleft `{pkg_name}` package to be present in `Cargo.toml`")
-    });
+    let stageleft_crate =
+        proc_macro_crate::crate_name(pkg_name).unwrap_or(FoundCrate::Name("stageleft".to_string()));
 
     match stageleft_crate {
         FoundCrate::Name(name) => syn::Ident::new(&name, Span::call_site()),

--- a/stageleft/src/runtime_support.rs
+++ b/stageleft/src/runtime_support.rs
@@ -13,9 +13,9 @@ pub struct QuoteTokens {
 }
 
 pub fn get_final_crate_name(crate_name: &str) -> TokenStream {
-    let final_crate = proc_macro_crate::crate_name(crate_name).unwrap_or_else(|_| {
-        panic!("Expected consumer `{crate_name}` package to be present in `Cargo.toml`")
-    });
+    let final_crate = proc_macro_crate::crate_name(crate_name).unwrap_or(
+        proc_macro_crate::FoundCrate::Name(crate_name.replace('-', "_")),
+    );
 
     match final_crate {
         proc_macro_crate::FoundCrate::Itself => {


### PR DESCRIPTION

Instead of generating an entirely separate `__staged` module, we now enable compilation using an environment variable. This makes test-mode trybuild compilation significantly faster, because all the tests can share the common compiled `__staged`.
