### PR TITLE
feat(stageleft): implement `FreeVariableWithContext` for owned `String`

### DIFF
--- a/stageleft/src/runtime_support.rs
+++ b/stageleft/src/runtime_support.rs
@@ -147,6 +147,17 @@ impl<Ctx> FreeVariableWithContext<Ctx> for &str {
     }
 }
 
+impl<Ctx> FreeVariableWithContext<Ctx> for String {
+    type O = &'static str;
+
+    fn to_tokens(self, _ctx: &Ctx) -> QuoteTokens {
+        QuoteTokens {
+            prelude: None,
+            expr: Some(quote!(#self)),
+        }
+    }
+}
+
 pub struct Import<T> {
     module_path: &'static str,
     crate_name: &'static str,


### PR DESCRIPTION

Helps sidestep some lifetime issues when the `&str` cannot be captured for a longer lifetime. Worth re-investigating lifetimes to improve `&str` behavior at some point.
