### PR TITLE
feat(stageleft): add support for property annotations in `q!` macro

### DIFF
--- a/stageleft/src/properties.rs
+++ b/stageleft/src/properties.rs
@@ -1,0 +1,14 @@
+/// A "property builder", which can accumulate annotations on a quoted snippet through chained
+/// function calls that may change the builder's type.
+pub trait Property: Sized {
+    /// A version of this property with all the annotations removed, on which annotations will be applied.
+    type Root;
+
+    /// Constructs a root instance of the property with all annotations removed.
+    fn make_root(target: &mut Option<Self>) -> Self::Root;
+}
+
+impl Property for () {
+    type Root = ();
+    fn make_root(_target: &mut Option<Self>) -> Self::Root {}
+}

--- a/stageleft/src/runtime_support.rs
+++ b/stageleft/src/runtime_support.rs
@@ -1,11 +1,8 @@
-use std::borrow::BorrowMut;
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-
-use crate::QuotedWithContext;
 
 pub struct QuoteTokens {
     pub prelude: Option<TokenStream>,
@@ -39,7 +36,7 @@ thread_local! {
 }
 
 pub fn set_macro_to_crate(macro_name: &str, crate_name: &str) {
-    MACRO_TO_CRATE.with_borrow_mut(|cell| {
+    MACRO_TO_CRATE.with(|cell| {
         *cell.borrow_mut() = Some((macro_name.to_string(), crate_name.to_string()));
     });
 }
@@ -81,10 +78,12 @@ impl ParseFromLiteral for bool {
 impl_parse_from_literal_numeric!(i8, i16, i32, i64, i128, isize);
 impl_parse_from_literal_numeric!(u8, u16, u32, u64, u128, usize);
 
-pub trait FreeVariableWithContext<Ctx> {
+/// A variant of `FreeVariableWithContext` that also has a properties type parameter.
+/// When `Props = ()`, this is equivalent to `FreeVariableWithContext`.
+pub trait FreeVariableWithContextWithProps<Ctx, Props> {
     type O;
 
-    fn to_tokens(self, ctx: &Ctx) -> QuoteTokens
+    fn to_tokens(self, ctx: &Ctx) -> (QuoteTokens, Props)
     where
         Self: Sized;
 
@@ -96,12 +95,28 @@ pub trait FreeVariableWithContext<Ctx> {
     }
 }
 
+pub trait FreeVariableWithContext<Ctx>: FreeVariableWithContextWithProps<Ctx, ()> {
+    fn to_tokens(self, ctx: &Ctx) -> QuoteTokens
+    where
+        Self: Sized,
+    {
+        FreeVariableWithContextWithProps::to_tokens(self, ctx).0
+    }
+
+    fn uninitialized(&self, ctx: &Ctx) -> <Self as FreeVariableWithContextWithProps<Ctx, ()>>::O {
+        FreeVariableWithContextWithProps::uninitialized(self, ctx)
+    }
+}
+
+/// Blanket impl: anything implementing FreeVariableWithContextWithProps<Ctx, ()> also implements FreeVariableWithContext
+impl<Ctx, T: FreeVariableWithContextWithProps<Ctx, ()>> FreeVariableWithContext<Ctx> for T {}
+
 pub trait FreeVariable<O>: FreeVariableWithContext<(), O = O> {
     fn to_tokens(self) -> QuoteTokens
     where
         Self: Sized,
     {
-        FreeVariableWithContext::to_tokens(self, &())
+        FreeVariableWithContextWithProps::to_tokens(self, &()).0
     }
 
     fn uninitialized(&self) -> O {
@@ -117,18 +132,18 @@ impl<O, T: FreeVariableWithContext<(), O = O>> FreeVariable<O> for T {}
 macro_rules! impl_free_variable_from_literal_numeric {
     ($($ty:ty),*) => {
         $(
-            impl <Ctx> FreeVariableWithContext<Ctx> for $ty {
+            impl<Ctx> FreeVariableWithContextWithProps<Ctx, ()> for $ty {
                 type O = $ty;
 
-                fn to_tokens(self, _ctx: &Ctx) -> QuoteTokens {
-                    QuoteTokens {
+                fn to_tokens(self, _ctx: &Ctx) -> (QuoteTokens, ()) {
+                    (QuoteTokens {
                         prelude: None,
                         expr: Some(quote!(#self))
-                    }
+                    }, ())
                 }
             }
 
-            impl<'a, Ctx> QuotedWithContext<'a, $ty, Ctx> for $ty {}
+            impl<'a, Ctx> crate::QuotedWithContextWithProps<'a, $ty, Ctx, ()> for $ty {}
         )*
     };
 }
@@ -136,25 +151,31 @@ macro_rules! impl_free_variable_from_literal_numeric {
 impl_free_variable_from_literal_numeric!(i8, i16, i32, i64, i128, isize);
 impl_free_variable_from_literal_numeric!(u8, u16, u32, u64, u128, usize);
 
-impl<Ctx> FreeVariableWithContext<Ctx> for &str {
+impl<Ctx> FreeVariableWithContextWithProps<Ctx, ()> for &str {
     type O = &'static str;
 
-    fn to_tokens(self, _ctx: &Ctx) -> QuoteTokens {
-        QuoteTokens {
-            prelude: None,
-            expr: Some(quote!(#self)),
-        }
+    fn to_tokens(self, _ctx: &Ctx) -> (QuoteTokens, ()) {
+        (
+            QuoteTokens {
+                prelude: None,
+                expr: Some(quote!(#self)),
+            },
+            (),
+        )
     }
 }
 
-impl<Ctx> FreeVariableWithContext<Ctx> for String {
+impl<Ctx> FreeVariableWithContextWithProps<Ctx, ()> for String {
     type O = &'static str;
 
-    fn to_tokens(self, _ctx: &Ctx) -> QuoteTokens {
-        QuoteTokens {
-            prelude: None,
-            expr: Some(quote!(#self)),
-        }
+    fn to_tokens(self, _ctx: &Ctx) -> (QuoteTokens, ()) {
+        (
+            QuoteTokens {
+                prelude: None,
+                expr: Some(quote!(#self)),
+            },
+            (),
+        )
     }
 }
 
@@ -189,19 +210,22 @@ pub fn create_import<T>(
     }
 }
 
-impl<T, Ctx> FreeVariableWithContext<Ctx> for Import<T> {
+impl<T, Ctx> FreeVariableWithContextWithProps<Ctx, ()> for Import<T> {
     type O = T;
 
-    fn to_tokens(self, _ctx: &Ctx) -> QuoteTokens {
+    fn to_tokens(self, _ctx: &Ctx) -> (QuoteTokens, ()) {
         let final_crate_root = get_final_crate_name(self.crate_name);
 
         let module_path = syn::parse_str::<syn::Path>(self.module_path).unwrap();
         let parsed = syn::parse_str::<syn::Path>(self.path).unwrap();
         let as_ident = syn::Ident::new(self.as_name, Span::call_site());
-        QuoteTokens {
-            prelude: Some(quote!(use #final_crate_root::#module_path::#parsed as #as_ident;)),
-            expr: None,
-        }
+        (
+            QuoteTokens {
+                prelude: Some(quote!(use #final_crate_root::#module_path::#parsed as #as_ident;)),
+                expr: None,
+            },
+            (),
+        )
     }
 }
 

--- a/stageleft_macro/src/quote_impl/snapshots/capture_copy_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_copy_local@macro_tokens.snap
@@ -4,7 +4,11 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
             let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
@@ -27,6 +31,7 @@ fn main() {
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "(x__free + 2) + (x__free + 2)";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 #[allow(unused, non_upper_case_globals, non_snake_case, forget_non_drop)]
                 ::std::mem::forget(x__free);
                 unsafe {

--- a/stageleft_macro/src/quote_impl/snapshots/capture_copy_local_block@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_copy_local_block@macro_tokens.snap
@@ -4,7 +4,11 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
             let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
@@ -27,6 +31,7 @@ fn main() {
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "{ let _ = x__free + 2 ; let _ = x__free + 2 ; }";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 #[allow(unused, non_upper_case_globals, non_snake_case, forget_non_drop)]
                 ::std::mem::forget(x__free);
                 unsafe {

--- a/stageleft_macro/src/quote_impl/snapshots/capture_copy_local_block_let@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_copy_local_block_let@macro_tokens.snap
@@ -4,7 +4,11 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
             let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
@@ -27,6 +31,7 @@ fn main() {
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "{ let x = x__free + 2 ; let _ = x + 2 ; }";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 #[allow(unused, non_upper_case_globals, non_snake_case, forget_non_drop)]
                 ::std::mem::forget(x__free);
                 unsafe {

--- a/stageleft_macro/src/quote_impl/snapshots/capture_in_macro@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_in_macro@macro_tokens.snap
@@ -4,7 +4,11 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
             let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
@@ -27,6 +31,7 @@ fn main() {
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "dbg ! (x__free)";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 #[allow(unused, non_upper_case_globals, non_snake_case, forget_non_drop)]
                 ::std::mem::forget(x__free);
                 unsafe {

--- a/stageleft_macro/src/quote_impl/snapshots/capture_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_local@macro_tokens.snap
@@ -4,7 +4,11 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
             let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
@@ -27,6 +31,7 @@ fn main() {
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "x__free + 2";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 #[allow(unused, non_upper_case_globals, non_snake_case, forget_non_drop)]
                 ::std::mem::forget(x__free);
                 unsafe {

--- a/stageleft_macro/src/quote_impl/snapshots/capture_local_mut@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_local_mut@macro_tokens.snap
@@ -4,7 +4,11 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             #[allow(unused, non_upper_case_globals, non_snake_case)]
             let x__free = {
                 let _out = ::stageleft::runtime_support::FreeVariableWithContext::uninitialized(
@@ -27,6 +31,7 @@ fn main() {
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "x__free += 2";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 #[allow(unused, non_upper_case_globals, non_snake_case, forget_non_drop)]
                 ::std::mem::forget(x__free);
                 unsafe {

--- a/stageleft_macro/src/quote_impl/snapshots/non_capture_enum_creation@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/non_capture_enum_creation@macro_tokens.snap
@@ -4,12 +4,17 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             if true {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "Foo :: Bar { x : 1 }";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/non_capture_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/non_capture_local@macro_tokens.snap
@@ -4,12 +4,17 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             if true {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "{ let x = 1 ; x + 2 }";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/non_capture_struct_creation@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/non_capture_struct_creation@macro_tokens.snap
@@ -4,12 +4,17 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             if true {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "Foo { x : 1 }";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-2.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-2.snap
@@ -4,12 +4,17 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             if true {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "None";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-3.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-3.snap
@@ -4,12 +4,17 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             if true {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "Ok (1)";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-4.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-4.snap
@@ -4,12 +4,17 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             if true {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "Err (1)";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens.snap
@@ -4,12 +4,17 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             if true {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "Some (1)";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_macro/src/quote_impl/snapshots/simple@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/simple@macro_tokens.snap
@@ -4,12 +4,17 @@ expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
-        move |__stageleft_ctx: &_, __output: &mut ::stageleft::internal::QuotedOutput| {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
             if true {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
                 __output.tokens = "1 + 2";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
                 unsafe {
                     return ::std::mem::MaybeUninit::uninit().assume_init();
                 }

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -4,6 +4,7 @@ stageleft::stageleft_crate!(stageleft_test_macro);
 use stageleft::{BorrowBounds, IntoQuotedOnce, Quoted, RuntimeData, q};
 
 pub(crate) mod features;
+pub(crate) mod property_example;
 pub(crate) mod submodule;
 
 static GLOBAL_VAR: i32 = 42;
@@ -12,7 +13,9 @@ mod private {
     type SomeType = i32;
 
     #[allow(dead_code)]
-    fn function_using_absolute_type_path(_xyz: Option<crate::private::SomeType>) -> crate::private::SomeType {
+    fn function_using_absolute_type_path(
+        _xyz: Option<crate::private::SomeType>,
+    ) -> crate::private::SomeType {
         123
     }
 }

--- a/stageleft_test/src/property_example.rs
+++ b/stageleft_test/src/property_example.rs
@@ -1,0 +1,28 @@
+use std::marker::PhantomData;
+
+use stageleft::{IntoQuotedMut, QuotedWithContextWithProps, properties::Property, q};
+
+pub struct PropertiesType<Abc = ()>(PhantomData<Abc>);
+
+impl PropertiesType<()> {
+    pub fn example_property(self, _x: bool) -> PropertiesType<String> {
+        PropertiesType(PhantomData)
+    }
+}
+
+impl<Abc> Property for PropertiesType<Abc> {
+    type Root = PropertiesType<()>;
+
+    fn make_root(_target: &mut Option<Self>) -> Self::Root {
+        PropertiesType(PhantomData)
+    }
+}
+
+fn needing_properties<'a>(f: impl IntoQuotedMut<'a, i32, (), PropertiesType<String>>) {
+    let (_, _props) = f.splice_typed_ctx_props(&());
+}
+
+#[allow(unused, reason = "compilation test")]
+fn test_properties() {
+    needing_properties(q!(123, example_property = true));
+}

--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -184,11 +184,11 @@ impl VisitMut for GenFinalPubVistor {
 
     fn visit_use_path_mut(&mut self, i: &mut UsePath) {
         if i.ident == "crate" {
-            i.tree = Box::new(syn::UseTree::Path(UsePath {
+            *i.tree = syn::UseTree::Path(UsePath {
                 ident: parse_quote!(__staged),
                 colon2_token: Default::default(),
                 tree: i.tree.clone(),
-            }));
+            });
         }
 
         syn::visit_mut::visit_use_path_mut(self, i);
@@ -525,8 +525,10 @@ pub fn gen_staged_trybuild(
 pub fn gen_staged_pub() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
 
-    let raw_toml_manifest =
-        fs::read_to_string(Path::new("Cargo.toml")).unwrap().parse::<DocumentMut>().unwrap();
+    let raw_toml_manifest = fs::read_to_string(Path::new("Cargo.toml"))
+        .unwrap()
+        .parse::<DocumentMut>()
+        .unwrap();
 
     let maybe_custom_lib_path = raw_toml_manifest
         .get("lib")


### PR DESCRIPTION

In Hydro, we are adding support for "algebraic annotations" that provide inline proofs of properties such as commutativity or idempotence next to the UDF. While it would be ideal to implement this as a separate macro that wraps Stageleft, we cannot do so due to type-inference limitations for Rust closures (inference does not work if the closure is in a tuple).

This PR adds native support for such properties to Stageleft. Developers can define custom `Property` types that act as builders that can gain properties through chained function calls. Then, `q!` can be invoked with additional args `prop1 = ..., prop2 = ...` which turn into invocations of `.prop1(...).prop2(...)`. These property builders can change the type of the result, which enables compile-time checking that the necessary properties are available.
