### PR TITLE
fix(stageleft_tool)!: remove `top_level_mod` and unused double-parsing code for trybuild mode

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -6,7 +6,7 @@ use proc_macro_crate::FoundCrate;
 use proc_macro2::Span;
 use quote::quote;
 
-pub use stageleft_macro::{entry, export, q, quse_fn, top_level_mod};
+pub use stageleft_macro::{entry, export, q, quse_fn};
 pub use type_name::{add_private_reexport, quote_type};
 
 #[doc(hidden)]

--- a/stageleft_macro/src/lib.rs
+++ b/stageleft_macro/src/lib.rs
@@ -134,42 +134,6 @@ pub fn quse_fn(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     .into()
 }
 
-/// A utility for declaring top-level public modules in a Stageleft crate that exports macros.
-///
-/// This gets around errors in compiling the macro crate when there
-/// are `pub mod` declarations at the top-level file.
-///
-/// This macro will only work on nightly with `#![feature(proc_macro_hygiene)]`,
-/// but for stable builds you can manually achieve this by using the following
-/// pattern:
-///
-/// ```ignore
-/// #[cfg(not(stageleft_macro))]
-/// pub mod my_mod;
-///
-/// #[cfg(stageleft_macro)]
-/// mod my_mod;
-/// ```
-#[proc_macro_attribute]
-pub fn top_level_mod(
-    _attr: proc_macro::TokenStream,
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
-    let input: syn::ItemMod = syn::parse(input).unwrap();
-    let mut input_pub_crate = input.clone();
-    if let syn::Visibility::Public(_) = &input_pub_crate.vis {
-        input_pub_crate.vis = syn::parse_quote!(pub(crate));
-    }
-
-    proc_macro::TokenStream::from(quote! {
-        #[cfg(not(stageleft_macro))]
-        #input
-
-        #[cfg(stageleft_macro)]
-        #input_pub_crate
-    })
-}
-
 /// Defines an entrypoint for staged code, which will be available as a proc macro.
 /// The entrypoint must be a function that returns `impl Quoted<T>` for some type `T`.
 ///


### PR DESCRIPTION

Leftover code resulted in double-loading and double-parsing of the entire crate's source tree, which doubled the latency of trybuild setup. Reduces latency of generating `__staged` for `hydro_lang` from ~1.5s to ~700ms.

This leftover code provided (broken) support for the no-longer-used `stageleft::top_level_mod`, so we remove that as well (breaking change).
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/hydro-project/stageleft/pull/51).
* #52
* __->__ #51