### PR TITLE
fix(stageleft): add BTreeSet and BTreeMap private reexport mappings

### DIFF
--- a/stageleft/src/type_name.rs
+++ b/stageleft/src/type_name.rs
@@ -41,6 +41,24 @@ static PRIVATE_REEXPORTS: ReexportsSet = LazyLock::new(|| {
             vec!["std".into(), "collections".into(), "hash_set".into()],
         ),
         (
+            vec![
+                "std".into(),
+                "collections".into(),
+                "btree".into(),
+                "map".into(),
+            ],
+            vec!["std".into(), "collections".into(), "btree_map".into()],
+        ),
+        (
+            vec![
+                "std".into(),
+                "collections".into(),
+                "btree".into(),
+                "set".into(),
+            ],
+            vec!["std".into(), "collections".into(), "btree_set".into()],
+        ),
+        (
             vec!["std".into(), "vec".into(), "into_iter".into()],
             vec!["std".into(), "vec".into()],
         ),


### PR DESCRIPTION
Added reexport path mappings for BTreeMap and BTreeSet in stageleft/src/type_name.rs PRIVATE_REEXPORTS, mapping:
- std::collections::btree::map → std::collections::btree_map
- std::collections::btree::set → std::collections::btree_set

This follows the existing pattern used for HashMap and HashSet.

Fixes https://github.com/hydro-project/stageleft/issues/61