### PR TITLE
fix: `gen_deps_module` to include optional dependencies with cfg-gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ perf.data.old
 flamegraph.svg
 
 /rustc-ice-*.txt
+/.infinity

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
 name = "stageleft_test"
 version = "0.0.0"
 dependencies = [
+ "once_cell",
  "rand",
  "stageleft",
  "stageleft_test_macro",
@@ -446,6 +447,7 @@ dependencies = [
 name = "stageleft_test_macro"
 version = "0.0.0"
 dependencies = [
+ "once_cell",
  "rand",
  "stageleft",
  "stageleft_tool",
@@ -455,7 +457,9 @@ dependencies = [
 name = "stageleft_test_no_entry"
 version = "0.0.0"
 dependencies = [
+ "cfg-if",
  "insta",
+ "once_cell",
  "slotmap",
  "stageleft",
  "stageleft_tool",

--- a/stageleft_test/Cargo.toml
+++ b/stageleft_test/Cargo.toml
@@ -14,12 +14,15 @@ release = false
 default = ["stageleft_macro_entrypoint"]
 stageleft_macro_entrypoint = []
 test_feature = []
+once_cell_feature = ["dep:once_cell", "stageleft_test_macro/once_cell_feature"]
 
 [dependencies]
 stageleft = { path = "../stageleft", version = "^0.13.2" }
 stageleft_test_macro = { path = "../stageleft_test_macro" }
 
 rand_alias = { package = "rand", version = "0.9.0", features = ["thread_rng"] }
+
+once_cell = { version = "1.20", optional = true }
 
 [build-dependencies]
 stageleft_tool = { path = "../stageleft_tool", version = "^0.13.2" }

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -91,6 +91,14 @@ fn captured_closure<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
     })
 }
 
+#[cfg(feature = "once_cell_feature")]
+#[stageleft::entry]
+pub fn using_once_cell(_ctx: BorrowBounds<'_>) -> impl Quoted<'_, i32> {
+    q!(*once_cell::sync::Lazy::force(&once_cell::sync::Lazy::new(
+        || 42
+    )))
+}
+
 #[cfg(stageleft_runtime)]
 #[cfg(test)]
 mod tests {
@@ -154,5 +162,12 @@ mod tests {
     fn test_submodule_public_struct() {
         let result: submodule::PublicStruct = submodule::public_struct!();
         assert_eq!(result.a, 1);
+    }
+
+    #[cfg(feature = "once_cell_feature")]
+    #[test]
+    fn test_using_once_cell() {
+        let result = using_once_cell!();
+        assert_eq!(result, 42);
     }
 }

--- a/stageleft_test_downstream/Cargo.toml
+++ b/stageleft_test_downstream/Cargo.toml
@@ -11,4 +11,4 @@ workspace = true
 release = false
 
 [dependencies]
-stageleft_test = { path = "../stageleft_test" }
+stageleft_test = { path = "../stageleft_test", features = ["once_cell_feature"] }

--- a/stageleft_test_downstream/src/lib.rs
+++ b/stageleft_test_downstream/src/lib.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use stageleft_test::{crate_paths, using_rand};
+    use stageleft_test::{crate_paths, using_once_cell, using_rand};
 
     #[test]
     fn test_quoted_using_dependency() {
@@ -10,5 +10,11 @@ mod tests {
     #[test]
     fn test_quoted_using_crate() {
         let _ = crate_paths!();
+    }
+
+    #[test]
+    fn test_quoted_using_optional_dep() {
+        let result = using_once_cell!();
+        assert_eq!(result, 42);
     }
 }

--- a/stageleft_test_macro/Cargo.toml
+++ b/stageleft_test_macro/Cargo.toml
@@ -12,6 +12,7 @@ release = false
 
 [features]
 test_feature = []
+once_cell_feature = ["dep:once_cell"]
 
 [lib]
 proc-macro = true
@@ -21,6 +22,8 @@ path = "../stageleft_test/src/lib.rs"
 stageleft = { path = "../stageleft", version = "^0.13.2" }
 
 rand_alias = { package = "rand", version = "0.9.0", features = ["thread_rng"] }
+
+once_cell = { version = "1.20", optional = true }
 
 [build-dependencies]
 stageleft_tool = { path = "../stageleft_tool", version = "^0.13.2" }

--- a/stageleft_test_no_entry/Cargo.toml
+++ b/stageleft_test_no_entry/Cargo.toml
@@ -17,6 +17,15 @@ stageleft = { path = "../stageleft", version = "^0.13.2" }
 
 slotmap = "1.0.0"
 
+# optional dep with implicit feature (feature "once_cell" auto-created)
+once_cell = { version = "1.20", optional = true }
+
+# optional dep gated by explicit feature via dep: syntax
+cfg-if = { version = "1.0", optional = true }
+
+[features]
+my_cfg_feature = ["dep:cfg-if"]
+
 [build-dependencies]
 stageleft_tool = { path = "../stageleft_tool", version = "^0.13.2" }
 

--- a/stageleft_test_no_entry/tests/snapshots/codegen_snapshot__staged_deps.snap
+++ b/stageleft_test_no_entry/tests/snapshots/codegen_snapshot__staged_deps.snap
@@ -5,30 +5,66 @@ expression: "include_str!(concat!(env!(\"OUT_DIR\"), stageleft::PATH_SEPARATOR!(
 pub mod __deps {
     pub use stageleft;
     pub use slotmap;
+    #[cfg(any(feature = "once_cell"))]
+    pub use once_cell;
+    #[cfg(any(feature = "my_cfg_feature"))]
+    pub use cfg_if;
     #[stageleft::internal::ctor::ctor(crate_path = stageleft::internal::ctor)]
     fn __init() {
-        stageleft::internal::add_deps_reexport(
-            vec!["stageleft"],
-            vec![
-                option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                    .unwrap_or(env!("CARGO_PKG_NAME"))
-                    .replace("-", "_"),
-                ::std::borrow::ToOwned::to_owned("__staged"),
-                ::std::borrow::ToOwned::to_owned("__deps"),
-                ::std::borrow::ToOwned::to_owned("stageleft"),
-            ],
-        );
-        stageleft::internal::add_deps_reexport(
-            vec!["slotmap"],
-            vec![
-                option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                    .unwrap_or(env!("CARGO_PKG_NAME"))
-                    .replace("-", "_"),
-                ::std::borrow::ToOwned::to_owned("__staged"),
-                ::std::borrow::ToOwned::to_owned("__deps"),
-                ::std::borrow::ToOwned::to_owned("slotmap"),
-            ],
-        );
+        {
+            stageleft::internal::add_deps_reexport(
+                vec!["stageleft"],
+                vec![
+                    option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                        .unwrap_or(env!("CARGO_PKG_NAME"))
+                        .replace("-", "_"),
+                    ::std::borrow::ToOwned::to_owned("__staged"),
+                    ::std::borrow::ToOwned::to_owned("__deps"),
+                    ::std::borrow::ToOwned::to_owned("stageleft"),
+                ],
+            );
+        }
+        {
+            stageleft::internal::add_deps_reexport(
+                vec!["slotmap"],
+                vec![
+                    option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                        .unwrap_or(env!("CARGO_PKG_NAME"))
+                        .replace("-", "_"),
+                    ::std::borrow::ToOwned::to_owned("__staged"),
+                    ::std::borrow::ToOwned::to_owned("__deps"),
+                    ::std::borrow::ToOwned::to_owned("slotmap"),
+                ],
+            );
+        }
+        #[cfg(any(feature = "once_cell"))]
+        {
+            stageleft::internal::add_deps_reexport(
+                vec!["once_cell"],
+                vec![
+                    option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                        .unwrap_or(env!("CARGO_PKG_NAME"))
+                        .replace("-", "_"),
+                    ::std::borrow::ToOwned::to_owned("__staged"),
+                    ::std::borrow::ToOwned::to_owned("__deps"),
+                    ::std::borrow::ToOwned::to_owned("once_cell"),
+                ],
+            );
+        }
+        #[cfg(any(feature = "my_cfg_feature"))]
+        {
+            stageleft::internal::add_deps_reexport(
+                vec!["cfg_if"],
+                vec![
+                    option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                        .unwrap_or(env!("CARGO_PKG_NAME"))
+                        .replace("-", "_"),
+                    ::std::borrow::ToOwned::to_owned("__staged"),
+                    ::std::borrow::ToOwned::to_owned("__deps"),
+                    ::std::borrow::ToOwned::to_owned("cfg_if"),
+                ],
+            );
+        }
         stageleft::internal::add_crate_with_staged(
             env!("CARGO_PKG_NAME").replace("-", "_"),
         );

--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -404,31 +404,77 @@ impl VisitMut for GenFinalPubVisitor {
     }
 }
 
+/// For an optional dependency, compute the list of features that enable it.
+/// If no feature references `dep:<name>`, Cargo creates an implicit feature with the dep's name.
+/// If one or more features reference `dep:<name>`, those are the gating features.
+fn optional_dep_features(dep_name: &str, features_table: Option<&toml_edit::Table>) -> Vec<String> {
+    let dep_prefix = format!("dep:{dep_name}");
+    let dep_prefix_slash = format!("{dep_prefix}/");
+    let explicit: Vec<String> = features_table
+        .into_iter()
+        .flat_map(|t| t.iter())
+        .filter(|(_, vals)| {
+            vals.as_array().is_some_and(|arr| {
+                arr.iter().any(|v| {
+                    v.as_str()
+                        .is_some_and(|s| s == dep_prefix || s.starts_with(&dep_prefix_slash))
+                })
+            })
+        })
+        .map(|(feat, _)| feat.to_owned())
+        .collect();
+    if explicit.is_empty() {
+        vec![dep_name.to_owned()]
+    } else {
+        explicit
+    }
+}
+
+/// Build a `#[cfg(...)]` attribute for the given feature list, or `None` if not optional.
+fn cfg_attr_for_features(features: &[String]) -> Option<syn::Attribute> {
+    if features.is_empty() {
+        return None;
+    }
+    let preds = features
+        .iter()
+        .map(|f| -> syn::Meta { parse_quote!(feature = #f) });
+    Some(parse_quote!(#[cfg(any(#(#preds),*))]))
+}
+
 fn gen_deps_module(stageleft_name: syn::Ident, manifest_path: &Path) -> syn::ItemMod {
     // based on proc-macro-crate
     let toml_parsed = fs::read_to_string(manifest_path)
         .unwrap()
         .parse::<DocumentMut>()
         .unwrap();
+    let features_table = toml_parsed.get("features").and_then(|v| v.as_table());
     let all_crate_names = toml_parsed["dependencies"]
         .as_table()
         .unwrap()
         .iter()
-        .filter(|(_, v)| !v.get("optional").and_then(|o| o.as_bool()).unwrap_or(false))
         .map(|(name, v)| {
+            let is_optional = v.get("optional").and_then(|o| o.as_bool()).unwrap_or(false);
+            let gating_features = if is_optional {
+                optional_dep_features(name, features_table)
+            } else {
+                vec![]
+            };
             (
                 name.replace('-', "_"),
                 v.get("package")
                     .map(|v| v.as_str().unwrap().replace("-", "_")),
+                gating_features,
             )
         })
         .collect::<Vec<_>>();
 
     let deps_reexported = all_crate_names
         .iter()
-        .map(|(name, _)| {
+        .map(|(name, _, gating_features)| {
             let name_ident = syn::Ident::new(name, Span::call_site());
+            let cfg = cfg_attr_for_features(gating_features);
             parse_quote! {
+                #cfg
                 pub use #name_ident;
             }
         })
@@ -436,20 +482,24 @@ fn gen_deps_module(stageleft_name: syn::Ident, manifest_path: &Path) -> syn::Ite
 
     let deps_reexported_runtime = all_crate_names
         .iter()
-        .map(|(name, original_crate_name)| {
+        .map(|(name, original_crate_name, gating_features)| {
             let original_crate_name_or_alias = original_crate_name.as_deref().unwrap_or(name);
+            let cfg = cfg_attr_for_features(gating_features);
             parse_quote! {
-                #stageleft_name::internal::add_deps_reexport(
-                    vec![#original_crate_name_or_alias],
-                    vec![
-                        option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                            .unwrap_or(env!("CARGO_PKG_NAME"))
-                            .replace("-", "_"),
-                        ::std::borrow::ToOwned::to_owned("__staged"),
-                        ::std::borrow::ToOwned::to_owned("__deps"),
-                        ::std::borrow::ToOwned::to_owned(#name),
-                    ]
-                );
+                #cfg
+                {
+                    #stageleft_name::internal::add_deps_reexport(
+                        vec![#original_crate_name_or_alias],
+                        vec![
+                            option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                                .unwrap_or(env!("CARGO_PKG_NAME"))
+                                .replace("-", "_"),
+                            ::std::borrow::ToOwned::to_owned("__staged"),
+                            ::std::borrow::ToOwned::to_owned("__deps"),
+                            ::std::borrow::ToOwned::to_owned(#name),
+                        ]
+                    );
+                }
             }
         })
         .collect::<Vec<syn::Stmt>>();
@@ -663,6 +713,154 @@ mod tests {
         assert!(
             generated_code.contains("add_deps_reexport"),
             "Generated code should contain add_deps_reexport calls: {}",
+            generated_code
+        );
+    }
+
+    #[test]
+    fn test_gen_deps_module_optional_implicit_feature() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(temp_file, "[dependencies]").unwrap();
+        writeln!(temp_file, r#"required_dep = "1.0""#).unwrap();
+        writeln!(
+            temp_file,
+            r#"optional_dep = {{ version = "2.0", optional = true }}"#
+        )
+        .unwrap();
+        temp_file.flush().unwrap();
+
+        let stageleft_name = syn::Ident::new("stageleft", Span::call_site());
+        let deps_module = gen_deps_module(stageleft_name, temp_file.path());
+        let generated_code = quote::quote!(#deps_module).to_string();
+
+        // required dep should not be gated
+        assert!(
+            !generated_code.contains(r#"feature = "required_dep""#),
+            "Required dep should not have cfg gate: {}",
+            generated_code
+        );
+        // optional dep with no explicit dep: reference gets implicit feature
+        assert!(
+            generated_code.contains(r#"any (feature = "optional_dep")"#),
+            "Optional dep should be gated by implicit feature: {}",
+            generated_code
+        );
+    }
+
+    #[test]
+    fn test_gen_deps_module_optional_explicit_dep_ref() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(temp_file, "[dependencies]").unwrap();
+        writeln!(
+            temp_file,
+            r#"optional_dep = {{ version = "1.0", optional = true }}"#
+        )
+        .unwrap();
+        writeln!(temp_file, "\n[features]").unwrap();
+        writeln!(temp_file, r#"my_feature = ["dep:optional_dep"]"#).unwrap();
+        temp_file.flush().unwrap();
+
+        let stageleft_name = syn::Ident::new("stageleft", Span::call_site());
+        let deps_module = gen_deps_module(stageleft_name, temp_file.path());
+        let generated_code = quote::quote!(#deps_module).to_string();
+
+        assert!(
+            generated_code.contains(r#"any (feature = "my_feature")"#),
+            "Optional dep should be gated by explicit feature: {}",
+            generated_code
+        );
+        assert!(
+            !generated_code.contains(r#"any (feature = "optional_dep")"#),
+            "Implicit feature should be suppressed when dep: is used: {}",
+            generated_code
+        );
+    }
+
+    #[test]
+    fn test_gen_deps_module_optional_multiple_features() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(temp_file, "[dependencies]").unwrap();
+        writeln!(
+            temp_file,
+            r#"optional_dep = {{ version = "1.0", optional = true }}"#
+        )
+        .unwrap();
+        writeln!(temp_file, "\n[features]").unwrap();
+        writeln!(temp_file, r#"feat_a = ["dep:optional_dep"]"#).unwrap();
+        writeln!(temp_file, r#"feat_b = ["dep:optional_dep"]"#).unwrap();
+        temp_file.flush().unwrap();
+
+        let stageleft_name = syn::Ident::new("stageleft", Span::call_site());
+        let deps_module = gen_deps_module(stageleft_name, temp_file.path());
+        let generated_code = quote::quote!(#deps_module).to_string();
+
+        assert!(
+            generated_code.contains("any"),
+            "Multiple features should use cfg(any(...)): {}",
+            generated_code
+        );
+        assert!(
+            generated_code.contains(r#"feature = "feat_a""#),
+            "Should contain feat_a: {}",
+            generated_code
+        );
+        assert!(
+            generated_code.contains(r#"feature = "feat_b""#),
+            "Should contain feat_b: {}",
+            generated_code
+        );
+    }
+
+    #[test]
+    fn test_gen_deps_module_optional_implicit_feature_transitive() {
+        // When bar = ["foo"] and foo is optional with no dep:foo references,
+        // the implicit feature "foo" is used. Enabling bar enables foo transitively.
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(temp_file, "[dependencies]").unwrap();
+        writeln!(temp_file, r#"foo = {{ version = "1.0", optional = true }}"#).unwrap();
+        writeln!(temp_file, "\n[features]").unwrap();
+        writeln!(temp_file, r#"bar = ["foo"]"#).unwrap();
+        temp_file.flush().unwrap();
+
+        let stageleft_name = syn::Ident::new("stageleft", Span::call_site());
+        let deps_module = gen_deps_module(stageleft_name, temp_file.path());
+        let generated_code = quote::quote!(#deps_module).to_string();
+
+        // Should gate on the implicit feature "foo", not "bar"
+        assert!(
+            generated_code.contains(r#"any (feature = "foo")"#),
+            "Should gate on implicit feature foo: {}",
+            generated_code
+        );
+        assert!(
+            !generated_code.contains(r#"feature = "bar""#),
+            "Should not gate on bar (it enables foo transitively): {}",
+            generated_code
+        );
+    }
+
+    #[test]
+    fn test_gen_deps_module_optional_dep_in_default_feature() {
+        // Cargo sets cfg(feature = "default") when default features are enabled,
+        // so gating on "default" is correct behavior.
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(temp_file, "[dependencies]").unwrap();
+        writeln!(
+            temp_file,
+            r#"optional_dep = {{ version = "1.0", optional = true }}"#
+        )
+        .unwrap();
+        writeln!(temp_file, "\n[features]").unwrap();
+        writeln!(temp_file, r#"default = ["dep:optional_dep"]"#).unwrap();
+        temp_file.flush().unwrap();
+
+        let stageleft_name = syn::Ident::new("stageleft", Span::call_site());
+        let deps_module = gen_deps_module(stageleft_name, temp_file.path());
+        let generated_code = quote::quote!(#deps_module).to_string();
+
+        assert!(
+            generated_code.contains(r#"any (feature = "default")"#),
+            "Should gate on default feature: {}",
             generated_code
         );
     }


### PR DESCRIPTION
Previously, gen_deps_module unconditionally filtered out all optional dependencies from the generated __deps module. This meant optional deps were never re-exported, even when their corresponding feature was enabled.

Now optional dependencies are included but gated behind the correct #[cfg(any(feature = "..."))] attribute. The logic handles both Cargo cases:

1. Implicit feature: if no feature in [features] references `dep:<name>`, Cargo creates an implicit feature named after the dep.
2. Explicit `dep:` references: if one or more features reference `dep:<name>`, those are the gating features.

Changes:
- stageleft_tool/src/lib.rs: Added optional_dep_features() and cfg_attr_for_features() helpers, modified gen_deps_module to gate optional deps instead of filtering them out, added 4 unit tests.
- stageleft_test/Cargo.toml: Added once_cell as optional dep with once_cell_feature = ["dep:once_cell"].
- stageleft_test_macro/Cargo.toml: Matching once_cell optional dep and once_cell_feature forwarding.
- stageleft_test/src/lib.rs: Added using_once_cell staged entry and test.
- stageleft_test_downstream/Cargo.toml: Enabled once_cell_feature.
- stageleft_test_downstream/src/lib.rs: Added test_quoted_using_optional_dep.
- stageleft_test_no_entry/Cargo.toml: Added once_cell (implicit feature) and cfg-if (explicit dep: feature) as optional deps for snapshot testing.
- stageleft_test_no_entry/tests/snapshots/codegen_snapshot__staged_deps.snap: Updated to show cfg-gated optional deps in generated code.