### PR TITLE
fix: handle structural binding patterns in let statements within q!()

### DIFF
--- a/stageleft_macro/Cargo.toml
+++ b/stageleft_macro/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 quote = "1"
-syn = { version = "2", features = [ "full", "visit-mut", "extra-traits" ] }
+syn = { version = "2", features = [ "full", "visit", "visit-mut", "extra-traits" ] }
 proc-macro2 = "1"
 proc-macro-crate = "3.3"
 sha2 = "0.10.0"

--- a/stageleft_macro/src/quote_impl/free_variable/mod.rs
+++ b/stageleft_macro/src/quote_impl/free_variable/mod.rs
@@ -64,6 +64,19 @@ pub struct FreeVariableVisitor {
     pub current_scope: ScopeStack,
 }
 
+/// Visitor that only extracts bound identifiers from patterns,
+/// without triggering free variable detection on paths like `Some`.
+struct PatBindingVisitor<'a> {
+    scope: &'a mut ScopeStack,
+}
+
+impl syn::visit::Visit<'_> for PatBindingVisitor<'_> {
+    fn visit_pat_ident(&mut self, i: &syn::PatIdent) {
+        self.scope.insert_term(i.ident.clone());
+        syn::visit::visit_pat_ident(self, i);
+    }
+}
+
 impl syn::visit_mut::VisitMut for FreeVariableVisitor {
     fn visit_expr_closure_mut(&mut self, i: &mut syn::ExprClosure) {
         self.current_scope.push();
@@ -108,23 +121,10 @@ impl syn::visit_mut::VisitMut for FreeVariableVisitor {
             syn::visit_mut::visit_local_init_mut(self, init);
         });
 
-        match &mut i.pat {
-            syn::Pat::Ident(pat_ident) => {
-                self.current_scope.insert_term(pat_ident.ident.clone());
-            }
-            syn::Pat::Type(pat_type) => {
-                self.visit_pat_mut(&mut pat_type.pat);
-            }
-            syn::Pat::Wild(_) => {
-                // Do nothing
-            }
-            syn::Pat::Tuple(pat_tuple) => {
-                for el in &mut pat_tuple.elems {
-                    self.visit_pat_mut(el);
-                }
-            }
-            _ => panic!("Local variables must be identifiers, got {:?}", i.pat),
-        }
+        let mut binding_visitor = PatBindingVisitor {
+            scope: &mut self.current_scope,
+        };
+        syn::visit::Visit::visit_pat(&mut binding_visitor, &i.pat);
     }
 
     fn visit_ident_mut(&mut self, i: &mut proc_macro2::Ident) {

--- a/stageleft_macro/src/quote_impl/mod.rs
+++ b/stageleft_macro/src/quote_impl/mod.rs
@@ -251,6 +251,16 @@ mod tests {
     }
 
     #[test]
+    fn test_let_else_structural_binding() {
+        test_quote! {
+            || {
+                let Some(x) = Some(1) else { return };
+                x
+            }
+        }
+    }
+
+    #[test]
     fn test_prelude_enum_variants() {
         test_quote! {
             Some(1)

--- a/stageleft_macro/src/quote_impl/snapshots/let_else_structural_binding@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/let_else_structural_binding@macro_tokens.snap
@@ -1,0 +1,30 @@
+---
+source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 255
+expression: "prettyplease :: unparse(& wrapped)"
+---
+fn main() {
+    {
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
+            if true {
+                __output.module_path = module_path!();
+                __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.tokens = "| | { let Some (x) = Some (1) else { return } ; x }";
+                *__props = Some(stageleft::properties::Property::make_root(__props));
+                ::core::panic!("stageleft: q!() closure completed");
+            }
+            #[allow(unreachable_code, unused_qualifications)]
+            {
+                || {
+                    let Some(x) = Some(1) else { return };
+                    x
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #64

The `visit_local_mut` method previously had a hand-rolled match on pattern types that panicked on anything it didn't explicitly handle (like `let Some(x) = ... else { ... }`).

Using the main visitor's `visit_pat_mut` would incorrectly treat pattern paths like `Some` as free variables. Instead, this introduces a separate `PatBindingVisitor` that uses syn's read-only `Visit` trait to recursively walk patterns and only extract bound identifiers via `visit_pat_ident`, without triggering free variable detection on constructor paths.

Changes:
- Added `visit` feature to syn in `stageleft_macro/Cargo.toml`
- Added `PatBindingVisitor` struct in `free_variable/mod.rs`
- Replaced the match-based pattern handling in `visit_local_mut` with a call to the new visitor
- Added test + insta snapshot