### PR TITLE
fix: suppress panic hook stderr spam from q!() closure

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -490,11 +490,14 @@ impl<T, Ctx, Props, F: for<'b> FnOnce(&'b Ctx, &mut QuotedOutput, &mut Option<Pr
         // a T value (which would require UB to construct). We catch the panic.
         let output_ref = std::panic::AssertUnwindSafe(&mut output);
         let props_ref = std::panic::AssertUnwindSafe(&mut props);
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
             let output_ref = output_ref;
             let props_ref = props_ref;
             std::mem::forget(self(ctx, output_ref.0, props_ref.0));
         }));
+        std::panic::set_hook(prev_hook);
 
         let instantiated_free_variables = output.captures.iter().flat_map(|capture| {
             let ident = syn::Ident::new(capture.ident, Span::call_site());


### PR DESCRIPTION
The `q!()` macro closure panics with `"stageleft: q!() closure completed"` as its control flow mechanism, caught by `catch_unwind`. However, Rust's default panic hook prints the message to stderr before `catch_unwind` catches it, spamming test output with `--nocapture`.

This PR temporarily replaces the panic hook with a no-op around the `catch_unwind` call and restores it immediately after.