### PR TITLE
feat(stageleft): fix q! span attribution via hidden macro export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       CARGO_INCREMENTAL: 0
-      CARGO_PROFILE_DEV_STRIP: "debuginfo"
-      CARGO_PROFILE_TEST_STRIP: "debuginfo"
-      CARGO_PROFILE_RELEASE_STRIP: "debuginfo"
 
     steps:
       - name: Checkout sources
@@ -67,14 +64,14 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.event_name != 'pull_request' }}
     timeout-minutes: 50
     needs: pre_job
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     env:
       CARGO_TERM_COLOR: always
       CARGO_INCREMENTAL: 0
-      CARGO_PROFILE_DEV_STRIP: "debuginfo"
-      CARGO_PROFILE_TEST_STRIP: "debuginfo"
-      CARGO_PROFILE_RELEASE_STRIP: "debuginfo"
 
     steps:
       - name: Checkout sources
@@ -96,8 +93,14 @@ jobs:
             core.exportVariable('SCCACHE_GHA_ENABLED', 'true');
             core.exportVariable('RUSTC_WRAPPER', 'sccache');
 
-      - name: Install cargo-nextest
+      - name: Install cargo-nextest (Linux)
+        if: runner.os == 'Linux'
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
+      - name: Install cargo-nextest (Windows)
+        if: runner.os == 'Windows'
+        run: curl -LsSf https://get.nexte.st/latest/windows-tar | tar zxf - -C $env:USERPROFILE\.cargo\bin
+        shell: pwsh
 
       - name: Run cargo nextest on all targets
         run: cargo nextest run --no-fail-fast --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -483,7 +483,9 @@ dependencies = [
 name = "stageleft_test"
 version = "0.0.0"
 dependencies = [
+ "insta",
  "once_cell",
+ "prettyplease",
  "rand",
  "stageleft",
  "stageleft_test_macro",

--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -29,6 +29,9 @@ pub mod internal {
         pub crate_name: &'static str,
         pub tokens: &'static str,
         pub captures: Vec<Capture>,
+        pub macro_name: Option<&'static str>,
+        pub relative_paths: &'static [&'static str],
+        pub pkg_name: &'static str,
     }
 }
 
@@ -104,6 +107,17 @@ macro_rules! stageleft_no_entry_crate {
                 $crate::PATH_SEPARATOR!(),
                 "staged_deps.rs"
             ));
+        }
+
+        #[cfg(test)]
+        #[$crate::internal::ctor::ctor(crate_path = $crate::internal::ctor)]
+        fn __stageleft_register_test_modules() {
+            let (crate_name, modules) = include!(concat!(
+                env!("OUT_DIR"),
+                $crate::PATH_SEPARATOR!(),
+                "test_modules.rs"
+            ));
+            $crate::runtime_support::register_test_modules(crate_name, modules);
         }
     };
 }
@@ -692,108 +706,254 @@ impl<'a, T: 'a, Ctx, Props, F: FnOnce(&Ctx, &mut QuotedOutput, &mut Option<Props
 {
 }
 
+/// Resolves a relative path string (e.g. "crate :: Foo :: bar", "self :: func", "super :: X")
+/// to the concrete rewritten path for the splice site.
+fn resolve_relative_path(
+    path_str: &str,
+    final_crate_root: &proc_macro2::TokenStream,
+    module_path: Option<&syn::Path>,
+) -> proc_macro2::TokenStream {
+    let mut path: syn::Path = syn::parse_str(path_str).unwrap();
+
+    // Apply the same rewriting logic as RewritePaths
+    let crate_root_path: syn::Path = syn::parse_quote!(#final_crate_root::__staged);
+    let full_module_path: Option<syn::Path> =
+        module_path.map(|mp| syn::parse_quote!(#final_crate_root::__staged::#mp));
+
+    rewrite_paths::RewritePaths {
+        crate_root_path,
+        module_path: full_module_path,
+    }
+    .visit_path_mut(&mut path);
+
+    quote!(#path)
+}
+
+/// Generates the spliced token stream from a `QuotedOutput`.
+fn splice_quoted_output(output: &QuotedOutput) -> proc_macro2::TokenStream {
+    let final_crate_root = get_final_crate_name(output.crate_name);
+
+    let module_path: syn::Path = syn::parse_str(output.module_path).unwrap();
+    let module_path_segments = module_path
+        .segments
+        .iter()
+        .skip(1)
+        .cloned()
+        .collect::<Vec<_>>();
+    let module_path = if module_path_segments.is_empty()
+        || module_path_segments
+            .iter()
+            .any(|segment| segment.ident.to_string().starts_with("__doctest"))
+    {
+        None
+    } else {
+        Some(syn::Path {
+            leading_colon: None,
+            segments: syn::punctuated::Punctuated::from_iter(module_path_segments),
+        })
+    };
+
+    let macro_name = output
+        .macro_name
+        .expect("macro_name must be set when splicing");
+    let macro_ident = syn::Ident::new(macro_name, Span::call_site());
+
+    // Resolve path arguments
+    let path_args: Vec<proc_macro2::TokenStream> = output
+        .relative_paths
+        .iter()
+        .map(|path_str| resolve_relative_path(path_str, &final_crate_root, module_path.as_ref()))
+        .collect();
+
+    // Free variable expression arguments: `name = value`
+    let free_var_args: Vec<proc_macro2::TokenStream> = output
+        .captures
+        .iter()
+        .filter_map(|capture| {
+            let ident = syn::Ident::new(capture.ident, Span::call_site());
+            capture
+                .tokens
+                .expr
+                .as_ref()
+                .map(|expr| quote!(#ident = #expr))
+        })
+        .collect();
+
+    // Preludes (use statements) still go outside the macro invocation
+    let preludes: Vec<_> = output
+        .captures
+        .iter()
+        .filter_map(|capture| capture.tokens.prelude.clone())
+        .collect();
+
+    // Path arguments: `__sl_pN = resolved::path`
+    let named_path_args: Vec<proc_macro2::TokenStream> = path_args
+        .iter()
+        .enumerate()
+        .map(|(idx, p)| {
+            let name = syn::Ident::new(&format!("__sl_p{idx}"), Span::call_site());
+            quote!(#name = #p)
+        })
+        .collect();
+
+    let all_args: Vec<_> = named_path_args
+        .iter()
+        .map(|p| quote!(#p))
+        .chain(free_var_args.iter().map(|v| quote!(#v)))
+        .collect();
+
+    // Build the macro invocation path.
+    let macro_invocation = {
+        let literal_body: proc_macro2::TokenStream = output.tokens.parse().unwrap();
+        let final_crate = proc_macro_crate::crate_name(output.crate_name)
+            .unwrap_or_else(|_| panic!("Expected `{}` package in Cargo.toml", output.crate_name));
+        match final_crate {
+            FoundCrate::Itself => {
+                let pkg_name_underscore = output.pkg_name.replace('-', "_");
+
+                let module_path_without_crate = output
+                    .module_path
+                    .strip_prefix(&pkg_name_underscore)
+                    .and_then(|s| s.strip_prefix("::"))
+                    .unwrap_or("");
+
+                let is_inside_crate = output.module_path == pkg_name_underscore
+                    || output
+                        .module_path
+                        .starts_with(&format!("{pkg_name_underscore}::"));
+
+                if !is_inside_crate
+                    || runtime_support::is_test_module(output.crate_name, module_path_without_crate)
+                {
+                    // Build fallback body: replace __sl_pN idents with resolved paths
+                    let free_var_let_bindings: Vec<proc_macro2::TokenStream> = output
+                        .captures
+                        .iter()
+                        .filter_map(|capture| {
+                            let ident = syn::Ident::new(capture.ident, Span::call_site());
+                            capture
+                                .tokens
+                                .expr
+                                .as_ref()
+                                .map(|expr| quote!(let #ident = #expr;))
+                        })
+                        .collect();
+                    let mut fallback_expr: syn::Expr = syn::parse_str(output.tokens).unwrap();
+                    // Replace __sl_pN path prefixes with resolved paths
+                    struct MetavarRewriter<'a> {
+                        path_args: &'a [proc_macro2::TokenStream],
+                    }
+                    impl VisitMut for MetavarRewriter<'_> {
+                        fn visit_path_mut(&mut self, path: &mut syn::Path) {
+                            if let Some(first) = path.segments.first()
+                                && let Some(idx_str) = first.ident.to_string().strip_prefix("__sl_p")
+                                && let Ok(idx) = idx_str.parse::<usize>()
+                                && let Some(resolved) = self.path_args.get(idx)
+                            {
+                                let resolved_path: syn::Path =
+                                    syn::parse2(resolved.clone()).unwrap();
+                                let remaining: Vec<_> =
+                                    path.segments.iter().skip(1).cloned().collect();
+                                *path = resolved_path;
+                                for seg in remaining {
+                                    path.segments.push(seg);
+                                }
+                            }
+                            syn::visit_mut::visit_path_mut(self, path);
+                        }
+
+                        fn visit_macro_mut(&mut self, i: &mut syn::Macro) {
+                            attempt_transform_macro::attempt_transform_macro(self, i);
+                        }
+                    }
+                    MetavarRewriter { path_args: &path_args }.visit_expr_mut(&mut fallback_expr);
+                    quote!({
+                        #(#free_var_let_bindings)*
+                        #fallback_expr
+                    })
+                } else {
+                    quote!(
+                        #[allow(unused_imports)]
+                        use crate::*;
+                        #macro_ident!([#(#all_args,)*] [#literal_body])
+                    )
+                }
+            }
+            FoundCrate::Name(name) => {
+                let crate_ident = syn::Ident::new(&name, Span::call_site());
+                quote!(#crate_ident::#macro_ident!([#(#all_args,)*] [#literal_body]))
+            }
+        }
+    };
+
+    if let Some(module_path) = &module_path {
+        quote!({
+            use #final_crate_root::__staged::__deps::*;
+            use #final_crate_root::__staged::#module_path::*;
+            #(#preludes)*
+            #macro_invocation
+        })
+    } else {
+        quote!({
+            use #final_crate_root::__staged::__deps::*;
+            use #final_crate_root::__staged::*;
+            #(#preludes)*
+            #macro_invocation
+        })
+    }
+}
+
+/// Invokes a quoted closure, capturing its output via catch_unwind.
+fn invoke_quoted<T, Ctx, Props>(
+    f: impl FnOnce(&Ctx, &mut QuotedOutput, &mut Option<Props>) -> T,
+    ctx: &Ctx,
+) -> (QuotedOutput, Props) {
+    static GLOBAL_HOOK_MUTEX: parking_lot::ReentrantMutex<()> =
+        parking_lot::ReentrantMutex::new(());
+
+    let mut output = QuotedOutput {
+        module_path: "",
+        crate_name: "",
+        tokens: "",
+        captures: Vec::new(),
+        macro_name: None,
+        relative_paths: &[],
+        pkg_name: "",
+    };
+
+    let mut props = None;
+
+    let output_ref = std::panic::AssertUnwindSafe(&mut output);
+    let props_ref = std::panic::AssertUnwindSafe(&mut props);
+    let _guard = GLOBAL_HOOK_MUTEX.lock();
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        let output_ref = output_ref;
+        let props_ref = props_ref;
+        std::mem::forget(f(ctx, output_ref.0, props_ref.0));
+    }));
+    std::panic::set_hook(prev_hook);
+    drop(_guard);
+
+    (output, props.unwrap())
+}
+
 impl<T, Ctx, Props, F: for<'b> FnOnce(&'b Ctx, &mut QuotedOutput, &mut Option<Props>) -> T>
     FreeVariableWithContextWithProps<Ctx, Props> for F
 {
     type O = T;
 
     fn to_tokens(self, ctx: &Ctx) -> (QuoteTokens, Props) {
-        static GLOBAL_HOOK_MUTEX: parking_lot::ReentrantMutex<()> =
-            parking_lot::ReentrantMutex::new(());
-
-        let mut output = QuotedOutput {
-            module_path: "",
-            crate_name: "",
-            tokens: "",
-            captures: Vec::new(),
-        };
-
-        let mut props = None;
-
-        // The closure panics after setting output fields instead of returning
-        // a T value (which would require UB to construct). We catch the panic.
-        let output_ref = std::panic::AssertUnwindSafe(&mut output);
-        let props_ref = std::panic::AssertUnwindSafe(&mut props);
-        let _guard = GLOBAL_HOOK_MUTEX.lock();
-        let prev_hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(|_| {}));
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-            let output_ref = output_ref;
-            let props_ref = props_ref;
-            std::mem::forget(self(ctx, output_ref.0, props_ref.0));
-        }));
-        std::panic::set_hook(prev_hook);
-        drop(_guard);
-
-        let instantiated_free_variables = output.captures.iter().flat_map(|capture| {
-            let ident = syn::Ident::new(capture.ident, Span::call_site());
-            capture
-                .tokens
-                .prelude
-                .iter()
-                .map(|prelude| quote!(#prelude))
-                .chain(
-                    capture
-                        .tokens
-                        .expr
-                        .iter()
-                        .map(move |value| quote!(let #ident = #value;)),
-                )
-        });
-
-        let final_crate_root = get_final_crate_name(output.crate_name);
-
-        let module_path: syn::Path = syn::parse_str(output.module_path).unwrap();
-        let module_path_segments = module_path
-            .segments
-            .iter()
-            .skip(1)
-            .cloned()
-            .collect::<Vec<_>>();
-        let module_path = if module_path_segments.is_empty()
-            || module_path_segments
-                .iter()
-                .any(|segment| segment.ident.to_string().starts_with("__doctest"))
-        {
-            None
-        } else {
-            Some(syn::Path {
-                leading_colon: None,
-                segments: syn::punctuated::Punctuated::from_iter(module_path_segments),
-            })
-        };
-
-        let mut expr: syn::Expr = syn::parse_str(output.tokens).unwrap();
-        rewrite_paths::RewritePaths {
-            crate_root_path: syn::parse_quote!(#final_crate_root::__staged),
-            module_path: module_path
-                .clone()
-                .map(|module_path| syn::parse_quote!(#final_crate_root::__staged::#module_path)),
-        }
-        .visit_expr_mut(&mut expr);
-
-        let with_env = if let Some(module_path) = module_path {
-            quote!({
-                use #final_crate_root::__staged::__deps::*;
-                use #final_crate_root::__staged::#module_path::*;
-                #(#instantiated_free_variables)*
-                #expr
-            })
-        } else {
-            quote!({
-                use #final_crate_root::__staged::__deps::*;
-                use #final_crate_root::__staged::*;
-                #(#instantiated_free_variables)*
-                #expr
-            })
-        };
+        let (output, props) = invoke_quoted(self, ctx);
+        let with_env = splice_quoted_output(&output);
 
         (
             QuoteTokens {
                 prelude: None,
                 expr: Some(with_env),
             },
-            props.unwrap(),
+            props,
         )
     }
 }

--- a/stageleft/src/runtime_support.rs
+++ b/stageleft/src/runtime_support.rs
@@ -47,6 +47,29 @@ pub fn set_macro_to_crate(macro_name: impl Into<String>, crate_name: impl Into<S
     });
 }
 
+static TEST_MODULES: std::sync::RwLock<Vec<(&'static str, &'static [&'static str])>> =
+    std::sync::RwLock::new(Vec::new());
+
+/// Register test module paths for a crate. Called from ctor in generated code.
+pub fn register_test_modules(crate_name: &'static str, modules: &'static [&'static str]) {
+    TEST_MODULES.write().unwrap().push((crate_name, modules));
+}
+
+/// Check if a module path is inside a test module for the given crate.
+pub(crate) fn is_test_module(crate_name: &str, module_path: &str) -> bool {
+    let guard = TEST_MODULES.read().unwrap();
+    for (name, modules) in guard.iter() {
+        if *name == crate_name {
+            for test_mod in modules.iter() {
+                if module_path == *test_mod || module_path.starts_with(&format!("{test_mod}::")) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
 pub trait ParseFromLiteral {
     fn parse_from_literal(literal: &syn::Expr) -> Self;
 }

--- a/stageleft/tests/compile-fail/closure_capture_lifetime.rs
+++ b/stageleft/tests/compile-fail/closure_capture_lifetime.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)]
 use stageleft::*;
 
 fn closure_capture_lifetime_2<'a, I: Copy + Into<u32>>(

--- a/stageleft/tests/compile-fail/closure_capture_lifetime.stderr
+++ b/stageleft/tests/compile-fail/closure_capture_lifetime.stderr
@@ -1,13 +1,14 @@
 error[E0309]: the parameter type `I` may not live long enough
- --> tests/compile-fail/closure_capture_lifetime.rs:7:8
+ --> tests/compile-fail/closure_capture_lifetime.rs:8:8
   |
-3 | fn closure_capture_lifetime_2<'a, I: Copy + Into<u32>>(
+4 | fn closure_capture_lifetime_2<'a, I: Copy + Into<u32>>(
   |                               -- the parameter type `I` must be valid for the lifetime `'a` as defined here...
 ...
-7 |     q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32 + 'a>)
+8 |     q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32 + 'a>)
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `I` will meet its required lifetime bounds
   |
+  = note: this error originates in the macro `__stageleft_quote_tests_compile_fail_closure_capture_lifetime_rs_8_7` which comes from the expansion of the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding an explicit lifetime bound
   |
-3 | fn closure_capture_lifetime_2<'a, I: Copy + Into<u32> + 'a>(
+4 | fn closure_capture_lifetime_2<'a, I: Copy + Into<u32> + 'a>(
   |                                                       ++++

--- a/stageleft/tests/compile-fail/unresolved_identifier.rs
+++ b/stageleft/tests/compile-fail/unresolved_identifier.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)]
 use stageleft::*;
 
 fn main() {

--- a/stageleft/tests/compile-fail/unresolved_identifier.stderr
+++ b/stageleft/tests/compile-fail/unresolved_identifier.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `xyz` in this scope
- --> tests/compile-fail/unresolved_identifier.rs:7:9
+ --> tests/compile-fail/unresolved_identifier.rs:8:9
   |
-7 |         xyz
+8 |         xyz
   |         ^^^ not found in this scope

--- a/stageleft/tests/compile_fail.rs
+++ b/stageleft/tests/compile_fail.rs
@@ -1,5 +1,12 @@
 #[test]
 fn test_all() {
+    // Set STAGELEFT_FINAL_CRATE_MANIFEST_DIR so q!() generates portable macro names
+    unsafe {
+        std::env::set_var(
+            "STAGELEFT_FINAL_CRATE_MANIFEST_DIR",
+            env!("CARGO_MANIFEST_DIR"),
+        );
+    }
     let t = trybuild::TestCases::new();
     let path = "tests/compile-fail/*.rs";
     t.compile_fail(path);

--- a/stageleft_macro/Cargo.toml
+++ b/stageleft_macro/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 quote = "1"
 syn = { version = "2", features = [ "full", "visit", "visit-mut", "extra-traits" ] }
-proc-macro2 = "1"
+proc-macro2 = { version = "1.0.103", features = ["span-locations"] }
 proc-macro-crate = "3.3"
 sha2 = "0.10.0"
 

--- a/stageleft_macro/src/quote_impl/free_variable/mod.rs
+++ b/stageleft_macro/src/quote_impl/free_variable/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 mod prelude;
 use prelude::is_prelude;
@@ -61,7 +61,10 @@ impl ScopeStack {
 #[derive(Default)]
 pub struct FreeVariableVisitor {
     pub free_variables: BTreeSet<syn::Ident>,
+    pub relative_paths: BTreeMap<String, usize>,
     pub current_scope: ScopeStack,
+    /// When true, rewrite relative path prefixes to __sl_pN idents in-place.
+    pub rewrite_paths: bool,
 }
 
 /// Visitor that only extracts bound identifiers from patterns,
@@ -142,6 +145,40 @@ impl syn::visit_mut::VisitMut for FreeVariableVisitor {
     }
 
     fn visit_path_mut(&mut self, i: &mut syn::Path) {
+        // Collect and rewrite relative path prefixes (crate::, self::, super::)
+        if self.rewrite_paths
+            && i.leading_colon.is_none()
+            && i.segments.len() > 1
+            && let Some(first) = i.segments.first()
+            && (first.ident == "crate" || first.ident == "self" || first.ident == "super")
+        {
+            let prefix_len = if first.ident == "crate" {
+                1
+            } else {
+                i.segments
+                    .iter()
+                    .take_while(|s| s.ident == "self" || s.ident == "super")
+                    .count()
+            };
+            let prefix_segments: Vec<_> = i.segments.iter().take(prefix_len).collect();
+            let key = quote::quote!(#(#prefix_segments)::*).to_string();
+            let next_idx = self.relative_paths.len();
+            let idx = *self.relative_paths.entry(key).or_insert(next_idx);
+
+            let metavar = syn::Ident::new(&format!("__sl_p{idx}"), proc_macro2::Span::call_site());
+            let remaining: Vec<_> = i.segments.iter().skip(prefix_len).cloned().collect();
+            i.segments.clear();
+            i.segments.push(syn::PathSegment::from(metavar));
+            for seg in remaining {
+                i.segments.push(seg);
+            }
+            // Visit path arguments in remaining segments
+            for node in i.segments.iter_mut().skip(1) {
+                self.visit_path_arguments_mut(&mut node.arguments);
+            }
+            return;
+        }
+
         if i.leading_colon.is_none() && !is_prelude(&i.segments.first().unwrap().ident) {
             let one_segment = i.segments.len() == 1;
             let node = i.segments.first_mut().unwrap();

--- a/stageleft_macro/src/quote_impl/mod.rs
+++ b/stageleft_macro/src/quote_impl/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
 use syn::Token;
@@ -49,21 +51,200 @@ impl Parse for QInput {
     }
 }
 
+
+/// Rewrites a token stream to replace path metavar idents with `$ident` references
+/// for use inside a macro_rules! body.
+fn rewrite_body_for_macro(
+    body: &TokenStream,
+    relative_paths: &BTreeMap<String, usize>,
+) -> TokenStream {
+    let metavar_idents: std::collections::HashSet<String> = relative_paths
+        .values()
+        .map(|idx| format!("__sl_p{idx}"))
+        .collect();
+
+    fn rewrite_stream(
+        stream: TokenStream,
+        metavar_idents: &std::collections::HashSet<String>,
+    ) -> TokenStream {
+        use proc_macro2::{Delimiter, Group, Punct, Spacing, TokenTree};
+
+        let mut result = Vec::new();
+        for tt in stream {
+            match tt {
+                TokenTree::Ident(ref ident) if metavar_idents.contains(&ident.to_string()) => {
+                    // Emit $($__sl_pN)::* for path prefix metavars
+                    // Inner group: ($__sl_pN)
+                    let inner: TokenStream = vec![
+                        TokenTree::Punct(Punct::new('$', Spacing::Joint)),
+                        tt.clone(),
+                    ]
+                    .into_iter()
+                    .collect();
+                    let inner_group = Group::new(Delimiter::Parenthesis, inner);
+                    // Outer: $(...) :: *
+                    result.push(TokenTree::Punct(Punct::new('$', Spacing::Alone)));
+                    result.push(TokenTree::Group(inner_group));
+                    result.push(TokenTree::Punct(Punct::new(':', Spacing::Joint)));
+                    result.push(TokenTree::Punct(Punct::new(':', Spacing::Alone)));
+                    result.push(TokenTree::Punct(Punct::new('*', Spacing::Alone)));
+                }
+                TokenTree::Group(group) => {
+                    let rewritten = rewrite_stream(group.stream(), metavar_idents);
+                    let mut new_group = Group::new(group.delimiter(), rewritten);
+                    new_group.set_span(group.span());
+                    result.push(TokenTree::Group(new_group));
+                }
+                other => result.push(other),
+            }
+        }
+        result.into_iter().collect()
+    }
+
+    rewrite_stream(body.clone(), &metavar_idents)
+}
+
 pub fn q_impl(root: TokenStream, toks: TokenStream) -> TokenStream {
     let parsed = syn::parse2::<QInput>(toks.clone());
 
     let (expr_toks, properties) = match parsed {
         Ok(input) => (input.expr.into_token_stream(), input.properties),
-        Err(_) => (toks, Vec::new()),
+        Err(_) => (toks.clone(), Vec::new()),
     };
 
-    let mut visitor = FreeVariableVisitor::default();
+    let is_rust_analyzer = std::env::var("RUST_ANALYZER_INTERNALS_DO_NOT_USE").is_ok();
+
+    let mut visitor = FreeVariableVisitor {
+        rewrite_paths: !is_rust_analyzer,
+        ..Default::default()
+    };
     let rewritten_toks = if let Ok(mut expr) = syn::parse2::<syn::Expr>(expr_toks.clone()) {
         visitor.visit_expr_mut(&mut expr);
         expr.into_token_stream()
     } else {
         expr_toks
     };
+
+    let relative_paths = visitor.relative_paths;
+
+    // Skip macro generation in Rust Analyzer mode for performance
+    let (hidden_macro, macro_name, relative_path_strs, tokens_str): (TokenStream, Option<String>, Vec<String>, String) =
+        if is_rust_analyzer {
+            (quote!(), None, vec![], String::new())
+        } else {
+            // Generate a hash for the hidden macro name using source file + span location + content
+            let span = toks
+                .into_iter()
+                .next()
+                .map(|t| t.span())
+                .unwrap_or_else(Span::call_site);
+            let start = span.start();
+            // Make the file path relative to the final crate's manifest dir for portability.
+            let file_path = std::path::PathBuf::from(span.file());
+            let canonical_file = file_path.canonicalize().unwrap_or(file_path);
+            let manifest_dir = std::path::PathBuf::from(
+                std::env::var("STAGELEFT_FINAL_CRATE_MANIFEST_DIR")
+                    .or_else(|_| std::env::var("CARGO_MANIFEST_DIR"))
+                    .expect("STAGELEFT_FINAL_CRATE_MANIFEST_DIR or CARGO_MANIFEST_DIR must be set"),
+            );
+            let canonical_manifest_dir = manifest_dir.canonicalize().unwrap_or(manifest_dir);
+            let relative_file = canonical_file
+                .strip_prefix(&canonical_manifest_dir)
+                .unwrap_or(&canonical_file)
+                .display()
+                .to_string();
+            // Build a deterministic macro name from the relative file path + location.
+            // Normalize to valid Rust identifier characters.
+            let normalized_file: String = relative_file
+                .chars()
+                .map(|c| if c.is_alphanumeric() { c } else { '_' })
+                .collect();
+            let macro_name = format!(
+                "__stageleft_quote_{normalized_file}_{}_{}",
+                start.line, start.column
+            );
+            let macro_name_ident = syn::Ident::new(&macro_name, Span::call_site());
+
+            // Build the hidden macro body: add $ prefixes to path metavar idents
+            let macro_body_toks = if !relative_paths.is_empty() {
+                rewrite_body_for_macro(&rewritten_toks, &relative_paths)
+            } else {
+                rewritten_toks.clone()
+            };
+
+            // Generate macro parameter patterns for paths: `__sl_p0 = $($__sl_p0:ident)::*`
+            let path_param_patterns: Vec<TokenStream> = {
+                let mut sorted: Vec<_> = relative_paths.iter().collect();
+                sorted.sort_by_key(|(_, idx)| *idx);
+                sorted
+                    .iter()
+                    .map(|(_, idx)| {
+                        let metavar = syn::Ident::new(&format!("__sl_p{idx}"), Span::call_site());
+                        quote!(#metavar = $($#metavar:ident)::*)
+                    })
+                    .collect()
+            };
+
+            // Generate macro parameter patterns for free variables: `x__free = $x__free:expr`
+            let free_var_param_patterns: Vec<TokenStream> = visitor
+                .free_variables
+                .iter()
+                .map(|i| {
+                    let i_free = syn::Ident::new(&format!("{i}__free"), Span::call_site());
+                    quote!(#i_free = $#i_free:expr)
+                })
+                .collect();
+
+            // All macro params: paths first, then free variables, then literal body match
+            let all_macro_params: Vec<&TokenStream> = path_param_patterns
+                .iter()
+                .chain(free_var_param_patterns.iter())
+                .collect();
+
+            // Generate let bindings for free variables inside the macro body
+            let free_var_let_bindings: Vec<TokenStream> = visitor
+                .free_variables
+                .iter()
+                .map(|i| {
+                    let i_free = syn::Ident::new(&format!("{i}__free"), Span::call_site());
+                    quote!(let #i_free = $#i_free;)
+                })
+                .collect();
+
+            // The literal body match is the path-rewritten tokens
+            let literal_body = &rewritten_toks;
+
+            let hidden_macro = quote! {
+                #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+                #[cfg_attr(not(stageleft_macro), macro_export)]
+                #[doc(hidden)]
+                macro_rules! #macro_name_ident {
+                    ([#(#all_macro_params,)*] [#literal_body]) => {
+                        {
+                            #[allow(non_snake_case)]
+                            {
+                                #(#free_var_let_bindings)*
+                                #macro_body_toks
+                            }
+                        }
+                    };
+                }
+            };
+
+            // Serialize relative paths for the splice site (sorted by index)
+            let relative_path_strs: Vec<&String> = {
+                let mut sorted: Vec<_> = relative_paths.iter().collect();
+                sorted.sort_by_key(|(_, idx)| *idx);
+                sorted.iter().map(|(path_str, _)| *path_str).collect()
+            };
+
+            (
+                hidden_macro,
+                Some(macro_name),
+                relative_path_strs.into_iter().cloned().collect(),
+                rewritten_toks.to_string(),
+            )
+        };
 
     // Get fn() -> T pointers BEFORE the if block so they're in scope for both branches.
     let uninit_fn_bindings = visitor.free_variables.iter().map(|i| {
@@ -110,14 +291,52 @@ pub fn q_impl(root: TokenStream, toks: TokenStream) -> TokenStream {
     };
 
     // necessary to ensure proper hover in Rust Analyzer
-    let expr_without_spans = if std::env::var("RUST_ANALYZER_INTERNALS_DO_NOT_USE").is_ok() {
+    let expr_without_spans = if is_rust_analyzer {
         // for unknown reasons, Rust Analyzer completions break if we emit the input as a string as well :(
         "".to_owned()
     } else {
-        rewritten_toks.to_string()
+        tokens_str
+    };
+
+    let macro_name_tokens = match &macro_name {
+        None => quote!(None),
+        Some(name) => quote!(Some(#name)),
+    };
+
+    // In non-RA mode, the unreachable block invokes the macro for type checking.
+    // In RA mode, paste the original tokens directly (paths resolve locally).
+    let unreachable_expr = if let Some(ref name) = macro_name {
+        let macro_ident = syn::Ident::new(name, Span::call_site());
+        // Pass original path prefixes (crate, self, super::super, etc.)
+        let path_prefix_args: Vec<TokenStream> = {
+            let mut sorted: Vec<_> = relative_paths.iter().collect();
+            sorted.sort_by_key(|(_, idx)| *idx);
+            sorted
+                .iter()
+                .map(|(prefix_str, idx)| {
+                    let prefix: syn::Path = syn::parse_str(prefix_str).unwrap();
+                    let name = syn::Ident::new(&format!("__sl_p{idx}"), Span::call_site());
+                    quote!(#name = #prefix)
+                })
+                .collect()
+        };
+        // Pass uninit values as free var args (already bound by uninit_invocations above)
+        let free_var_uninit_args: Vec<TokenStream> = visitor
+            .free_variables
+            .iter()
+            .map(|i| {
+                let i_free = syn::Ident::new(&format!("{i}__free"), Span::call_site());
+                quote!(#i_free = #i_free)
+            })
+            .collect();
+        quote!(#macro_ident!([#(#path_prefix_args,)* #(#free_var_uninit_args,)*] [#rewritten_toks]))
+    } else {
+        rewritten_toks
     };
 
     quote!({
+        #hidden_macro
+
         move |__stageleft_ctx: &_, __output: &mut ::#root::internal::QuotedOutput, __props: &mut _| {
             // Bind fn() -> T pointers before the if block so they're in scope everywhere.
             #(#uninit_fn_bindings)*
@@ -128,7 +347,10 @@ pub fn q_impl(root: TokenStream, toks: TokenStream) -> TokenStream {
 
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME").unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = #expr_without_spans;
+                __output.macro_name = #macro_name_tokens;
+                __output.relative_paths = &[#(#relative_path_strs),*];
 
                 *__props = Some(#props_builder);
 
@@ -138,11 +360,10 @@ pub fn q_impl(root: TokenStream, toks: TokenStream) -> TokenStream {
             }
 
             // Unreachable: provides return type T for type inference.
-            // Invoke the fn() -> T pointers to bind typed variables.
             #[allow(unreachable_code, unused_qualifications)]
             {
                 #(#uninit_invocations)*
-                #rewritten_toks
+                #unreachable_expr
             }
         }
     })

--- a/stageleft_macro/src/quote_impl/snapshots/capture_copy_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_copy_local@macro_tokens.snap
@@ -1,9 +1,19 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 414
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([x__free = $x__free:expr,] [(x__free + 2) + (x__free + 2)]) => {
+                { #[allow(non_snake_case)] { let x__free = $x__free; (x__free + 2) +
+                (x__free + 2) } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -27,7 +37,10 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "(x__free + 2) + (x__free + 2)";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
@@ -35,7 +48,9 @@ fn main() {
             {
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
                 let x__free = x__free();
-                (x__free + 2) + (x__free + 2)
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [x__free = x__free,] [(x__free + 2) + (x__free + 2)]
+                )
             }
         }
     }

--- a/stageleft_macro/src/quote_impl/snapshots/capture_copy_local_block@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_copy_local_block@macro_tokens.snap
@@ -1,9 +1,22 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 421
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            (
+                [x__free = $x__free:expr,] [{ let _ = x__free + 2; let _ = x__free + 2;
+                }]
+            ) => {
+                { #[allow(non_snake_case)] { let x__free = $x__free; { let _ = x__free +
+                2; let _ = x__free + 2; } } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -27,7 +40,10 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "{ let _ = x__free + 2 ; let _ = x__free + 2 ; }";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
@@ -35,10 +51,9 @@ fn main() {
             {
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
                 let x__free = x__free();
-                {
-                    let _ = x__free + 2;
-                    let _ = x__free + 2;
-                }
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [x__free = x__free,] [{ let _ = x__free + 2; let _ = x__free + 2; }]
+                )
             }
         }
     }

--- a/stageleft_macro/src/quote_impl/snapshots/capture_copy_local_block_let@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_copy_local_block_let@macro_tokens.snap
@@ -1,9 +1,19 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 429
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([x__free = $x__free:expr,] [{ let x = x__free + 2; let _ = x + 2; }]) => {
+                { #[allow(non_snake_case)] { let x__free = $x__free; { let x = x__free +
+                2; let _ = x + 2; } } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -27,7 +37,10 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "{ let x = x__free + 2 ; let _ = x + 2 ; }";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
@@ -35,10 +48,9 @@ fn main() {
             {
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
                 let x__free = x__free();
-                {
-                    let x = x__free + 2;
-                    let _ = x + 2;
-                }
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [x__free = x__free,] [{ let x = x__free + 2; let _ = x + 2; }]
+                )
             }
         }
     }

--- a/stageleft_macro/src/quote_impl/snapshots/capture_in_macro@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_in_macro@macro_tokens.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 454
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([x__free = $x__free:expr,] [dbg!(x__free)]) => {
+                { #[allow(non_snake_case)] { let x__free = $x__free; dbg!(x__free) } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -27,7 +36,10 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "dbg ! (x__free)";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
@@ -35,7 +47,9 @@ fn main() {
             {
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
                 let x__free = x__free();
-                dbg!(x__free)
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [x__free = x__free,] [dbg!(x__free)]
+                )
             }
         }
     }

--- a/stageleft_macro/src/quote_impl/snapshots/capture_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_local@macro_tokens.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 407
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([x__free = $x__free:expr,] [x__free + 2]) => {
+                { #[allow(non_snake_case)] { let x__free = $x__free; x__free + 2 } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -27,7 +36,10 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "x__free + 2";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
@@ -35,7 +47,9 @@ fn main() {
             {
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
                 let x__free = x__free();
-                x__free + 2
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [x__free = x__free,] [x__free + 2]
+                )
             }
         }
     }

--- a/stageleft_macro/src/quote_impl/snapshots/capture_local_mut@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/capture_local_mut@macro_tokens.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 437
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([x__free = $x__free:expr,] [x__free += 2]) => {
+                { #[allow(non_snake_case)] { let x__free = $x__free; x__free += 2 } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -27,7 +36,10 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "x__free += 2";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
@@ -35,7 +47,9 @@ fn main() {
             {
                 #[allow(unused, non_upper_case_globals, non_snake_case)]
                 let x__free = x__free();
-                x__free += 2;
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [x__free = x__free,] [x__free += 2]
+                )
             }
         }
     }

--- a/stageleft_macro/src/quote_impl/snapshots/let_else_structural_binding@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/let_else_structural_binding@macro_tokens.snap
@@ -1,10 +1,19 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
-assertion_line: 255
+assertion_line: 475
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([] [| | { let Some(x) = Some(1) else { return }; x }]) => {
+                { #[allow(non_snake_case)] { | | { let Some(x) = Some(1) else { return };
+                x } } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -14,16 +23,18 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "| | { let Some (x) = Some (1) else { return } ; x }";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
             #[allow(unreachable_code, unused_qualifications)]
             {
-                || {
-                    let Some(x) = Some(1) else { return };
-                    x
-                }
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [] [| | { let Some(x) = Some(1) else { return }; x }]
+                )
             }
         }
     }

--- a/stageleft_macro/src/quote_impl/snapshots/non_capture_enum_creation@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/non_capture_enum_creation@macro_tokens.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 468
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([] [Foo::Bar { x : 1 }]) => {
+                { #[allow(non_snake_case)] { Foo::Bar { x : 1 } } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -13,11 +22,15 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "Foo :: Bar { x : 1 }";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
-            #[allow(unreachable_code, unused_qualifications)] { Foo::Bar { x: 1 } }
+            #[allow(unreachable_code, unused_qualifications)]
+            { __stageleft_quote__parsed_string_1__1_0!([] [Foo::Bar { x : 1 }]) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/non_capture_local@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/non_capture_local@macro_tokens.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 444
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([] [{ let x = 1; x + 2 }]) => {
+                { #[allow(non_snake_case)] { { let x = 1; x + 2 } } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -13,17 +22,15 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "{ let x = 1 ; x + 2 }";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
             #[allow(unreachable_code, unused_qualifications)]
-            {
-                {
-                    let x = 1;
-                    x + 2
-                }
-            }
+            { __stageleft_quote__parsed_string_1__1_0!([] [{ let x = 1; x + 2 }]) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/non_capture_struct_creation@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/non_capture_struct_creation@macro_tokens.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 461
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([] [Foo { x : 1 }]) => {
+                { #[allow(non_snake_case)] { Foo { x : 1 } } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -13,11 +22,15 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "Foo { x : 1 }";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
-            #[allow(unreachable_code, unused_qualifications)] { Foo { x: 1 } }
+            #[allow(unreachable_code, unused_qualifications)]
+            { __stageleft_quote__parsed_string_1__1_0!([] [Foo { x : 1 }]) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-2.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-2.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 489
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_6__1_0 {
+            ([] [None]) => {
+                { #[allow(non_snake_case)] { None } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -13,11 +22,15 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "None";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_6__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
-            #[allow(unreachable_code, unused_qualifications)] { None }
+            #[allow(unreachable_code, unused_qualifications)]
+            { __stageleft_quote__parsed_string_6__1_0!([] [None]) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-3.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-3.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 493
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_11__1_0 {
+            ([] [Ok(1)]) => {
+                { #[allow(non_snake_case)] { Ok(1) } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -13,11 +22,15 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "Ok (1)";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_11__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
-            #[allow(unreachable_code, unused_qualifications)] { Ok(1) }
+            #[allow(unreachable_code, unused_qualifications)]
+            { __stageleft_quote__parsed_string_11__1_0!([] [Ok(1)]) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-4.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens-4.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 497
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_16__1_0 {
+            ([] [Err(1)]) => {
+                { #[allow(non_snake_case)] { Err(1) } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -13,11 +22,15 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "Err (1)";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_16__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
-            #[allow(unreachable_code, unused_qualifications)] { Err(1) }
+            #[allow(unreachable_code, unused_qualifications)]
+            { __stageleft_quote__parsed_string_16__1_0!([] [Err(1)]) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/prelude_enum_variants@macro_tokens.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 485
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([] [Some(1)]) => {
+                { #[allow(non_snake_case)] { Some(1) } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -13,11 +22,15 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "Some (1)";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
-            #[allow(unreachable_code, unused_qualifications)] { Some(1) }
+            #[allow(unreachable_code, unused_qualifications)]
+            { __stageleft_quote__parsed_string_1__1_0!([] [Some(1)]) }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/simple@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/simple@macro_tokens.snap
@@ -1,9 +1,18 @@
 ---
 source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 400
 expression: "prettyplease :: unparse(& wrapped)"
 ---
 fn main() {
     {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            ([] [1 + 2]) => {
+                { #[allow(non_snake_case)] { 1 + 2 } }
+            };
+        }
         move |
             __stageleft_ctx: &_,
             __output: &mut ::stageleft::internal::QuotedOutput,
@@ -13,11 +22,15 @@ fn main() {
                 __output.module_path = module_path!();
                 __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
                     .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
                 __output.tokens = "1 + 2";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
                 *__props = Some(stageleft::properties::Property::make_root(__props));
                 ::core::panic!("stageleft: q!() closure completed");
             }
-            #[allow(unreachable_code, unused_qualifications)] { 1 + 2 }
+            #[allow(unreachable_code, unused_qualifications)]
+            { __stageleft_quote__parsed_string_1__1_0!([] [1 + 2]) }
         }
     }
 }

--- a/stageleft_test/Cargo.toml
+++ b/stageleft_test/Cargo.toml
@@ -26,3 +26,7 @@ once_cell = { version = "1.20", optional = true }
 
 [build-dependencies]
 stageleft_tool = { path = "../stageleft_tool", version = "^0.14.0" }
+
+[dev-dependencies]
+insta = "1.39"
+prettyplease = { version = "0.2.0", features = ["verbatim"] }

--- a/stageleft_test/src/backtrace_test.rs
+++ b/stageleft_test/src/backtrace_test.rs
@@ -1,0 +1,36 @@
+use stageleft::{BorrowBounds, Quoted, q};
+
+#[stageleft::entry]
+pub fn panicking_entry(_ctx: BorrowBounds<'_>) -> impl Quoted<'_, i32> {
+    q!(panic!("q site panic"))
+}
+
+#[cfg(stageleft_runtime)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_panic_span_attribution() {
+        use std::sync::{Arc, Mutex};
+        let bt_store: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let bt_clone = bt_store.clone();
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |_| {
+            let bt = std::backtrace::Backtrace::force_capture();
+            *bt_clone.lock().unwrap() = Some(bt.to_string());
+        }));
+        let result = std::panic::catch_unwind(|| {
+            panicking_entry!();
+        });
+        std::panic::set_hook(prev_hook);
+        assert!(result.is_err());
+        let bt_str = bt_store.lock().unwrap().take().unwrap();
+        // The backtrace should contain a frame pointing to the q!() definition site
+        // (line 5 where `q!(panic!("q site panic"))` is written).
+        assert!(
+            bt_str.contains("backtrace_test.rs:5"),
+            "Backtrace should contain backtrace_test.rs:5 (the q! site), got:\n{bt_str}"
+        );
+    }
+}

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -104,11 +104,14 @@ fn ref_str<'a>(s: &str) -> impl Quoted<'a, &'static str> {
     q!(s)
 }
 
+pub(crate) mod backtrace_test;
+
 #[cfg(stageleft_runtime)]
 #[cfg(test)]
 mod tests {
     use super::*;
     use stageleft::QuotedWithContext;
+    use stageleft::internal::syn;
 
     #[test]
     fn test_raise_to_power_of_two() {
@@ -181,5 +184,41 @@ mod tests {
     fn test_quoting() {
         let quoted = q!(1 + 2);
         let _ = quoted.splice_typed_ctx(&());
+    }
+
+    #[test]
+    fn test_splice_snapshot_simple() {
+        let quoted = q!(1 + 2);
+        let expr = quoted.splice_untyped_ctx(&());
+        let file: syn::File = syn::parse_quote!(fn main() { #expr });
+        insta::assert_snapshot!(prettyplease::unparse(&file));
+    }
+
+    #[test]
+    fn test_splice_snapshot_free_var() {
+        let x = 42i32;
+        let quoted = q!(x + 1);
+        let expr = quoted.splice_untyped_ctx(&());
+        let file: syn::File = syn::parse_quote!(fn main() { #expr });
+        insta::assert_snapshot!(prettyplease::unparse(&file));
+    }
+
+    #[test]
+    fn test_splice_snapshot_crate_path() {
+        let expr = QuotedWithContext::splice_untyped_ctx(
+            crate_paths(stageleft::QuotedContext::create()),
+            &(),
+        );
+        let file: syn::File = syn::parse_quote!(fn main() { #expr });
+        insta::assert_snapshot!(prettyplease::unparse(&file));
+    }
+
+    #[test]
+    fn test_crate_path_in_macro() {
+        // This tests the fallback path (test module) with a relative path inside a macro call
+        let quoted = q!(assert!(crate::my_top_level_function()));
+        let expr = quoted.splice_untyped_ctx(&());
+        let file: syn::File = syn::parse_quote!(fn main() { #expr });
+        insta::assert_snapshot!(prettyplease::unparse(&file));
     }
 }

--- a/stageleft_test/src/snapshots/stageleft_test__tests__crate_path_in_macro.snap
+++ b/stageleft_test/src/snapshots/stageleft_test__tests__crate_path_in_macro.snap
@@ -1,0 +1,12 @@
+---
+source: stageleft_test/src/lib.rs
+assertion_line: 222
+expression: "prettyplease::unparse(&file)"
+---
+fn main() {
+    {
+        use crate::__staged::__deps::*;
+        use crate::__staged::tests::*;
+        { assert!(crate::__staged::my_top_level_function()) }
+    }
+}

--- a/stageleft_test/src/snapshots/stageleft_test__tests__splice_snapshot_crate_path.snap
+++ b/stageleft_test/src/snapshots/stageleft_test__tests__splice_snapshot_crate_path.snap
@@ -1,0 +1,16 @@
+---
+source: stageleft_test/src/lib.rs
+assertion_line: 208
+expression: "prettyplease::unparse(&file)"
+---
+fn main() {
+    {
+        use crate::__staged::__deps::*;
+        use crate::__staged::*;
+        #[allow(unused_imports)]
+        use crate::*;
+        __stageleft_quote_src_lib_rs_77_7!(
+            [__sl_p0 = crate ::__staged,] [__sl_p0::my_top_level_function()]
+        )
+    }
+}

--- a/stageleft_test/src/snapshots/stageleft_test__tests__splice_snapshot_free_var.snap
+++ b/stageleft_test/src/snapshots/stageleft_test__tests__splice_snapshot_free_var.snap
@@ -1,0 +1,15 @@
+---
+source: stageleft_test/src/lib.rs
+assertion_line: 198
+expression: "prettyplease::unparse(&file)"
+---
+fn main() {
+    {
+        use crate::__staged::__deps::*;
+        use crate::__staged::tests::*;
+        {
+            let x__free = 42i32;
+            x__free + 1
+        }
+    }
+}

--- a/stageleft_test/src/snapshots/stageleft_test__tests__splice_snapshot_simple.snap
+++ b/stageleft_test/src/snapshots/stageleft_test__tests__splice_snapshot_simple.snap
@@ -1,0 +1,12 @@
+---
+source: stageleft_test/src/lib.rs
+assertion_line: 189
+expression: "prettyplease::unparse(&file)"
+---
+fn main() {
+    {
+        use crate::__staged::__deps::*;
+        use crate::__staged::tests::*;
+        { 1 + 2 }
+    }
+}

--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -105,6 +105,10 @@ pub fn gen_macro(staged_path: &Path, crate_name: &str) {
     println!("cargo::rustc-check-cfg=cfg(stageleft_runtime)");
     println!("cargo::rerun-if-changed=build.rs");
     println!("cargo::rustc-env=STAGELEFT_FINAL_CRATE_NAME={crate_name}");
+    println!(
+        "cargo::rustc-env=STAGELEFT_FINAL_CRATE_MANIFEST_DIR={}",
+        staged_path_absolute.display()
+    );
     println!("cargo::rustc-cfg=stageleft_macro");
 
     println!(
@@ -598,8 +602,10 @@ pub fn gen_staged_trybuild(
     flow_lib_pub
 }
 
+/// Combined function that generates staged deps, test modules, and optionally lib_pub.
+/// Parses the source tree only once.
 #[doc(hidden)]
-pub fn gen_staged_pub() {
+pub fn gen_staged(gen_pub: bool) {
     let out_dir = env::var_os("OUT_DIR").unwrap();
 
     let raw_toml_manifest = fs::read_to_string(Path::new("Cargo.toml"))
@@ -612,27 +618,31 @@ pub fn gen_staged_pub() {
         .and_then(|lib| lib.get("path"))
         .and_then(|path| path.as_str());
 
-    let flow_lib_pub = gen_staged_mod(
-        maybe_custom_lib_path
-            .map(Path::new)
-            .unwrap_or_else(|| Path::new("src/lib.rs")),
-        parse_quote!(crate),
-        None,
-        false,
-    );
+    let lib_path = maybe_custom_lib_path
+        .map(Path::new)
+        .unwrap_or_else(|| Path::new("src/lib.rs"));
 
-    fs::write(
-        Path::new(&out_dir).join("lib_pub.rs"),
-        prettyplease::unparse(&flow_lib_pub),
-    )
-    .unwrap();
-    println!("cargo::rerun-if-changed=src");
-}
+    // Parse source once
+    let flow_lib = syn_inline_mod::parse_and_inline_modules(lib_path);
 
-#[doc(hidden)]
-pub fn gen_staged_deps() {
-    let out_dir = env::var_os("OUT_DIR").unwrap();
+    // Generate lib_pub.rs if requested
+    if gen_pub {
+        let flow_lib_pub = gen_staged_mod(
+            lib_path,
+            parse_quote!(crate),
+            None,
+            false,
+        );
 
+        fs::write(
+            Path::new(&out_dir).join("lib_pub.rs"),
+            prettyplease::unparse(&flow_lib_pub),
+        )
+        .unwrap();
+        println!("cargo::rerun-if-changed=src");
+    }
+
+    // Generate staged_deps.rs
     // Remove `_tool` suffix.
     let main_pkg_name = env!("CARGO_PKG_NAME").rsplit_once(['-', '_']).unwrap().0;
     let stageleft_crate = proc_macro_crate::crate_name(main_pkg_name).unwrap_or_else(|_| {
@@ -653,6 +663,50 @@ pub fn gen_staged_deps() {
         prettyplease::unparse(&parse_quote!(#deps_file)),
     )
     .unwrap();
+
+    // Collect test modules for fallback detection at splice time
+    struct TestModCollector {
+        current_mod: Vec<String>,
+        test_modules: Vec<String>,
+    }
+
+    impl<'a> Visit<'a> for TestModCollector {
+        fn visit_item_mod(&mut self, i: &'a syn::ItemMod) {
+            let is_test_mod = i
+                .attrs
+                .iter()
+                .any(|a| a.to_token_stream().to_string() == "# [cfg (test)]");
+
+            self.current_mod.push(i.ident.to_string());
+
+            if is_test_mod {
+                self.test_modules.push(self.current_mod.join("::"));
+            }
+
+            syn::visit::visit_item_mod(self, i);
+            self.current_mod.pop();
+        }
+    }
+
+    let mut collector = TestModCollector {
+        current_mod: Vec::new(),
+        test_modules: Vec::new(),
+    };
+    Visit::visit_file(&mut collector, &flow_lib);
+
+    let test_mod_strs = &collector.test_modules;
+    let crate_name_str = env::var("CARGO_PKG_NAME").unwrap().replace('-', "_");
+
+    let registration_body = quote::quote! {
+        (#crate_name_str, &[#(#test_mod_strs),*])
+    };
+
+    fs::write(
+        Path::new(&out_dir).join("test_modules.rs"),
+        registration_body.to_string(),
+    )
+    .unwrap();
+    println!("cargo::rerun-if-changed=src");
 }
 
 #[macro_export]
@@ -663,6 +717,10 @@ macro_rules! gen_final {
         println!("cargo::rustc-check-cfg=cfg(stageleft_trybuild)");
         println!("cargo::rustc-check-cfg=cfg(feature, values(\"stageleft_macro_entrypoint\"))");
         println!("cargo::rustc-cfg=stageleft_runtime");
+        println!(
+            "cargo::rustc-env=STAGELEFT_FINAL_CRATE_MANIFEST_DIR={}",
+            std::env::var("CARGO_MANIFEST_DIR").unwrap()
+        );
 
         println!("cargo::rerun-if-changed=Cargo.toml");
         println!("cargo::rerun-if-changed=build.rs");
@@ -672,16 +730,16 @@ macro_rules! gen_final {
             unexpected_cfgs,
             reason = "Macro entrypoints must define the stageleft_macro_entrypoint feature"
         )]
-        {
-            if cfg!(feature = "stageleft_macro_entrypoint") {
-                $crate::gen_staged_pub()
-            } else if std::env::var("STAGELEFT_TRYBUILD_BUILD_STAGED").is_ok() {
-                println!("cargo::rustc-cfg=stageleft_trybuild");
-                $crate::gen_staged_pub()
-            }
-        }
+        let gen_pub = if cfg!(feature = "stageleft_macro_entrypoint") {
+            true
+        } else if std::env::var("STAGELEFT_TRYBUILD_BUILD_STAGED").is_ok() {
+            println!("cargo::rustc-cfg=stageleft_trybuild");
+            true
+        } else {
+            false
+        };
 
-        $crate::gen_staged_deps()
+        $crate::gen_staged(gen_pub);
     };
 }
 


### PR DESCRIPTION
## Summary

When code inside a `q!()` panics at runtime, the backtrace now correctly points to the `q!()` definition site rather than the splice site.

## Background: How stageleft works today (before this PR)

When you write:
```rust
#[stageleft::entry]
fn my_entry(_ctx: BorrowBounds<'_>) -> impl Quoted<'_, i32> {
    q!(crate::compute(x + 1))
}
```

The `q!()` macro captures the expression as a string and stores it in a closure. At splice time (when the entry macro is invoked), `to_tokens()` parses that string, rewrites relative paths (`crate::` → `final_crate::__staged::`), and emits the expression as a `TokenStream`. The generated code looks like:

```rust
{
    use final_crate::__staged::*;
    let x__free = captured_value;
    final_crate::__staged::compute(x__free + 1)
}
```

The problem: all tokens in this output have `Span::call_site()` spans, so panics, backtraces, and compiler diagnostics point to the splice site — not the original `q!()` source location.

## How it works after this PR

`q!()` now emits a hidden `#[macro_export] macro_rules!` alongside the closure. The macro body contains the original expression tokens **with their source spans preserved**. At splice time, instead of emitting the expression directly, we emit an invocation of this macro. Because `macro_rules!` preserves definition-site spans in its expansion, the compiled code's debug info points back to the `q!()` source — so backtraces show the correct file and line.

### Full expansion of `q!()`

Given:
```rust
// src/lib.rs, line 5
q!(crate::compute(x + 1))
```

**In non-Rust-Analyzer mode**, `q!()` expands to:
```rust
{
    // Hidden macro with preserved source spans in the body
    #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
    #[cfg_attr(not(stageleft_macro), macro_export)]
    #[doc(hidden)]
    macro_rules! __stageleft_quote_src_lib_rs_5_7 {
        ([__sl_p0 = $($__sl_p0:ident)::*, x__free = $x__free:expr,]
         [__sl_p0 :: compute(x__free + 1)]) => {
            {
                #[allow(non_snake_case)]
                {
                    let x__free = $x__free;
                    $($__sl_p0)::*::compute(x__free + 1)
                }
            }
        };
    }

    move |__stageleft_ctx: &_, __output: &mut QuotedOutput, __props: &mut _| {
        // fn() -> T pointers for type inference
        let x__free = FreeVariableWithContext::uninitialized(&x, __stageleft_ctx);

        if true {
            // Capture free variables and store metadata
            __output.captures.push(Capture { ident: "x__free", tokens: ... });
            __output.module_path = module_path!();
            __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME").unwrap_or(env!("CARGO_PKG_NAME"));
            __output.pkg_name = env!("CARGO_PKG_NAME");
            __output.tokens = "__sl_p0 :: compute (x__free + 1)";
            __output.macro_name = Some("__stageleft_quote_src_lib_rs_5_7");
            __output.relative_paths = &["crate"];
            *__props = Some(...);
            panic!("stageleft: q!() closure completed");
        }

        // Unreachable: type inference block.
        // Invokes the just-defined macro with original path prefixes + uninit values.
        #[allow(unreachable_code, unused_qualifications)]
        {
            let x__free = x__free();
            __stageleft_quote_src_lib_rs_5_7!(
                [__sl_p0 = crate, x__free = x__free,]
                [__sl_p0 :: compute(x__free + 1)]
            )
        }
    }
}
```

**In Rust Analyzer mode**, the expansion is simpler (no macro generation, no path rewriting):
```rust
{
    move |__stageleft_ctx: &_, __output: &mut QuotedOutput, __props: &mut _| {
        let x__free = FreeVariableWithContext::uninitialized(&x, __stageleft_ctx);

        if true {
            __output.captures.push(...);
            // tokens field is empty in RA mode
            __output.tokens = "";
            __output.macro_name = None;
            ...
            panic!("stageleft: q!() closure completed");
        }

        // Unreachable: uses original paths directly (they resolve locally)
        #[allow(unreachable_code, unused_qualifications)]
        {
            let x__free = x__free();
            crate::compute(x__free + 1)  // original expression, unmodified
        }
    }
}
```

### At splice time

When the entry macro is invoked (e.g., `my_entry!()`), `to_tokens()` runs the closure via `catch_unwind`, extracts the metadata, and emits:

```rust
{
    use final_crate::__staged::__deps::*;
    use final_crate::__staged::*;
    use crate::*;  // brings #[macro_export] macros into scope
    __stageleft_quote_src_lib_rs_5_7!(
        [__sl_p0 = final_crate::__staged, x__free = captured_value,]
        [__sl_p0 :: compute(x__free + 1)]
    )
}
```

### Fallback path

When the macro isn't accessible (e.g., `q!()` was in a `#[cfg(test)]` module or an example binary), the splice emits the expression directly with path placeholders resolved at runtime:

```rust
{
    use final_crate::__staged::__deps::*;
    use final_crate::__staged::*;
    {
        let x__free = captured_value;
        final_crate::__staged::compute(x__free + 1)
    }
}
```

This loses span attribution but is functionally correct.

## Key design decisions

- **Macro naming**: The macro name is derived from the source file path (relative to crate root) + line + column, ensuring uniqueness and portability across machines.

- **Path handling**: Relative paths (`crate::`, `self::`, `super::`) in the `q!()` expression refer to items relative to where the `q!()` is written. But when the expression is spliced into a different crate (or a different module within the same crate), these paths would resolve incorrectly. Stageleft solves this by rewriting them to point through the `__staged` module, which re-exports all items as `pub`.

  In this PR, the rewriting is split into two parts:
  1. **At `q!()` expansion time**: Relative path prefixes are replaced with placeholder idents (`__sl_p0`, `__sl_p1`, etc.). For example, `crate::module::Foo` becomes `__sl_p0::module::Foo`. This happens in the same visitor pass that detects free variables.
  2. **At splice time**: The placeholders are resolved to concrete paths (e.g., `__sl_p0` → `final_crate::__staged`) and passed as macro arguments using `$($__sl_pN:ident)::*` repetition, which allows `macro_rules!` to concatenate the resolved prefix with the remaining path segments.

  This two-phase approach is necessary because the hidden macro is defined at `q!()` time (when the final crate name isn't known), but invoked at splice time (when it is). The `$($ident)::*` pattern is used instead of `:path` because `:path` fragments cannot be concatenated with `::suffix` in `macro_rules!`.

- **Free variables**: Passed as `:expr` parameters with `name = value` syntax. The macro body binds them with `let name = $name;`.

- **Literal body match**: The second `[...]` argument contains the expression tokens (post-path-rewrite). This serves as a coherence check — if downstream tooling mutates the AST, the macro pattern won't match.

- **Fallback for inaccessible macros**: When the `q!()` is in a `#[cfg(test)]` module or outside the crate (examples, trybuild), the macro may not be accessible. In these cases, the splice emits the expression directly with path resolution done at runtime.

- **Rust Analyzer mode**: All macro generation is skipped for performance; paths are left as-is for local resolution.

- **Single-pass visitor**: The `FreeVariableVisitor` now handles both free variable detection and path prefix rewriting in one traversal (when not in RA mode).

## Other changes

- `stageleft_tool`: `gen_macro` emits `STAGELEFT_FINAL_CRATE_MANIFEST_DIR` for portable path resolution. New `gen_staged(bool)` unifies deps/test-module/lib-pub generation with a single source parse.
- `stageleft_tool`: Registers `#[cfg(test)]` module paths via a ctor, enabling the fallback detection at splice time.
- CI: Removed `CARGO_PROFILE_*_STRIP: debuginfo` so backtrace tests can verify line numbers.
- `proc-macro2` bumped to 1.0.103 for `Span::file()` API.