### PR TITLE
fix!: allow quoting of types with lifetimes

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -448,25 +448,24 @@ fn stageleft_root() -> syn::Ident {
     }
 }
 
-pub trait IntoQuotedOnce<'a, T, Ctx, Props = ()>:
-    for<'b> FnOnce(&'b Ctx, &mut QuotedOutput, &mut Option<Props>) -> T
-    + 'a
+pub trait IntoQuotedOnce<'a, T: 'a, Ctx, Props = ()>:
+    FnOnce(&Ctx, &mut QuotedOutput, &mut Option<Props>) -> T
     + QuotedWithContextWithProps<'a, T, Ctx, Props>
 {
-    fn boxed(self) -> Box<dyn IntoQuotedOnce<'a, T, Ctx, Props>>
+    fn boxed(self) -> Box<dyn 'a + IntoQuotedOnce<'a, T, Ctx, Props>>
     where
-        Self: Sized,
+        Self: 'a + Sized,
     {
         Box::new(self)
     }
 }
 
-impl<'a, T, Ctx, Props, F: for<'b> FnOnce(&'b Ctx, &mut QuotedOutput, &mut Option<Props>) -> T + 'a>
+impl<'a, T: 'a, Ctx, Props, F: FnOnce(&Ctx, &mut QuotedOutput, &mut Option<Props>) -> T>
     QuotedWithContextWithProps<'a, T, Ctx, Props> for F
 {
 }
 
-impl<'a, T, Ctx, Props, F: for<'b> FnOnce(&'b Ctx, &mut QuotedOutput, &mut Option<Props>) -> T + 'a>
+impl<'a, T: 'a, Ctx, Props, F: FnOnce(&Ctx, &mut QuotedOutput, &mut Option<Props>) -> T>
     IntoQuotedOnce<'a, T, Ctx, Props> for F
 {
 }
@@ -577,12 +576,12 @@ impl<T, Ctx, Props, F: for<'b> FnOnce(&'b Ctx, &mut QuotedOutput, &mut Option<Pr
     }
 }
 
-pub trait IntoQuotedMut<'a, T, Ctx, Props = ()>:
-    FnMut(&Ctx, &mut QuotedOutput, &mut Option<Props>) -> T + 'a
+pub trait IntoQuotedMut<'a, T: 'a, Ctx, Props = ()>:
+    FnMut(&Ctx, &mut QuotedOutput, &mut Option<Props>) -> T
 {
 }
 
-impl<'a, T, Ctx, Props, F: FnMut(&Ctx, &mut QuotedOutput, &mut Option<Props>) -> T + 'a>
+impl<'a, T: 'a, Ctx, Props, F: FnMut(&Ctx, &mut QuotedOutput, &mut Option<Props>) -> T>
     IntoQuotedMut<'a, T, Ctx, Props> for F
 {
 }

--- a/stageleft/tests/compile-fail/closure_capture_lifetime.rs
+++ b/stageleft/tests/compile-fail/closure_capture_lifetime.rs
@@ -4,7 +4,7 @@ fn closure_capture_lifetime_2<'a, I: Copy + Into<u32>>(
     _ctx: BorrowBounds<'a>,
     v: RuntimeData<I>,
 ) -> impl Quoted<'a, Box<dyn Fn() -> u32 + 'a>> {
-    q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32>)
+    q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32 + 'a>)
 }
 
 fn main() {}

--- a/stageleft/tests/compile-fail/closure_capture_lifetime.rs
+++ b/stageleft/tests/compile-fail/closure_capture_lifetime.rs
@@ -1,0 +1,10 @@
+use stageleft::*;
+
+fn closure_capture_lifetime_2<'a, I: Copy + Into<u32>>(
+    _ctx: BorrowBounds<'a>,
+    v: RuntimeData<I>,
+) -> impl Quoted<'a, Box<dyn Fn() -> u32 + 'a>> {
+    q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32>)
+}
+
+fn main() {}

--- a/stageleft/tests/compile-fail/closure_capture_lifetime.stderr
+++ b/stageleft/tests/compile-fail/closure_capture_lifetime.stderr
@@ -1,0 +1,13 @@
+error[E0309]: the parameter type `I` may not live long enough
+ --> tests/compile-fail/closure_capture_lifetime.rs:7:8
+  |
+3 | fn closure_capture_lifetime_2<'a, I: Copy + Into<u32>>(
+  |                               -- the parameter type `I` must be valid for the lifetime `'a` as defined here...
+...
+7 |     q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32>)
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `I` will meet its required lifetime bounds
+  |
+help: consider adding an explicit lifetime bound
+  |
+3 | fn closure_capture_lifetime_2<'a, I: Copy + Into<u32> + 'a>(
+  |                                                       ++++

--- a/stageleft/tests/compile-fail/closure_capture_lifetime.stderr
+++ b/stageleft/tests/compile-fail/closure_capture_lifetime.stderr
@@ -4,8 +4,8 @@ error[E0309]: the parameter type `I` may not live long enough
 3 | fn closure_capture_lifetime_2<'a, I: Copy + Into<u32>>(
   |                               -- the parameter type `I` must be valid for the lifetime `'a` as defined here...
 ...
-7 |     q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32>)
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `I` will meet its required lifetime bounds
+7 |     q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32 + 'a>)
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `I` will meet its required lifetime bounds
   |
 help: consider adding an explicit lifetime bound
   |

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -65,7 +65,7 @@ fn closure_capture_lifetime<'a, I: Copy + Into<u32> + 'a>(
     _ctx: BorrowBounds<'a>,
     v: RuntimeData<I>,
 ) -> impl Quoted<'a, Box<dyn Fn() -> u32 + 'a>> {
-    q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32>)
+    q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32 + 'a>)
 }
 
 fn my_top_level_function() -> bool {
@@ -97,6 +97,11 @@ pub fn using_once_cell(_ctx: BorrowBounds<'_>) -> impl Quoted<'_, i32> {
     q!(*once_cell::sync::Lazy::force(&once_cell::sync::Lazy::new(
         || 42
     )))
+}
+
+#[expect(dead_code, reason = "test code")]
+fn ref_str<'a>(s: &str) -> impl Quoted<'a, &'static str> {
+    q!(s)
 }
 
 #[cfg(stageleft_runtime)]

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -65,7 +65,7 @@ fn closure_capture_lifetime<'a, I: Copy + Into<u32> + 'a>(
     _ctx: BorrowBounds<'a>,
     v: RuntimeData<I>,
 ) -> impl Quoted<'a, Box<dyn Fn() -> u32 + 'a>> {
-    q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32 + 'a>)
+    q!(Box::new(move || { v.into() }) as Box<dyn Fn() -> u32>)
 }
 
 fn my_top_level_function() -> bool {


### PR DESCRIPTION
The previous bounds were overly restrictive, effectively require `Self: 'a` when in reality we only need `T: 'a` (where `T` is the output type resulting from quoting)

BREAKING CHANGE: `T: 'a` bound may need to be added to implementers of these traits.