### PR TITLE
feat(stageleft): add FnMut variant of fn2_borrow_mut splicing

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -380,6 +380,26 @@ pub trait QuotedWithContextWithProps<'a, T, Ctx, Props>:
             props,
         )
     }
+
+    fn splice_fnmut2_borrow_mut_ctx_props<I1, I2, O>(self, ctx: &Ctx) -> (syn::Expr, Props)
+    where
+        Self: Sized,
+        T: FnMut(&mut I1, I2) -> O,
+    {
+        let (inner_expr, props) = self.splice_untyped_ctx_props(ctx);
+        let stageleft_root = stageleft_root();
+
+        let in1_type = quote_type::<I1>();
+        let in2_type = quote_type::<I2>();
+        let out_type = quote_type::<O>();
+
+        (
+            syn::parse_quote! {
+                #stageleft_root::runtime_support::fnmut2_borrow_mut_type_hint::<#in1_type, #in2_type, #out_type>(#inner_expr)
+            },
+            props,
+        )
+    }
 }
 
 pub trait QuotedWithContext<'a, T, Ctx>: QuotedWithContextWithProps<'a, T, Ctx, ()> {
@@ -483,6 +503,14 @@ pub trait QuotedWithContext<'a, T, Ctx>: QuotedWithContextWithProps<'a, T, Ctx, 
         T: FnMut(&I1, &I2) -> O,
     {
         QuotedWithContextWithProps::splice_fnmut2_borrow_ctx_props(self, ctx).0
+    }
+
+    fn splice_fnmut2_borrow_mut_ctx<I1, I2, O>(self, ctx: &Ctx) -> syn::Expr
+    where
+        Self: Sized,
+        T: FnMut(&mut I1, I2) -> O,
+    {
+        QuotedWithContextWithProps::splice_fnmut2_borrow_mut_ctx_props(self, ctx).0
     }
 
     fn splice_untyped(self) -> syn::Expr
@@ -659,6 +687,24 @@ pub trait QuotedWithContext<'a, T, Ctx>: QuotedWithContextWithProps<'a, T, Ctx, 
 
         syn::parse_quote! {
             #stageleft_root::runtime_support::fnmut2_borrow_type_hint::<#in1_type, #in2_type, #out_type>(#inner_expr)
+        }
+    }
+
+    fn splice_fnmut2_borrow_mut<I1, I2, O>(self) -> syn::Expr
+    where
+        Self: Sized,
+        Ctx: Default,
+        T: FnMut(&mut I1, I2) -> O,
+    {
+        let inner_expr = QuotedWithContext::splice_untyped(self);
+        let stageleft_root = stageleft_root();
+
+        let in1_type = quote_type::<I1>();
+        let in2_type = quote_type::<I2>();
+        let out_type = quote_type::<O>();
+
+        syn::parse_quote! {
+            #stageleft_root::runtime_support::fnmut2_borrow_mut_type_hint::<#in1_type, #in2_type, #out_type>(#inner_expr)
         }
     }
 }

--- a/stageleft/src/runtime_support.rs
+++ b/stageleft/src/runtime_support.rs
@@ -310,3 +310,9 @@ pub fn fnmut2_borrow_type_hint<'a, I1, I2, O>(
 ) -> impl FnMut(&I1, &I2) -> O + 'a {
     f
 }
+
+pub fn fnmut2_borrow_mut_type_hint<'a, I1, I2, O>(
+    f: impl FnMut(&mut I1, I2) -> O + 'a,
+) -> impl FnMut(&mut I1, I2) -> O + 'a {
+    f
+}

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -218,6 +218,14 @@ mod tests {
     }
 
     #[test]
+    fn test_splice_snapshot_fnmut2_borrow_mut() {
+        let quoted = q!(|state: &mut i32, item: i32| *state += item);
+        let expr = quoted.splice_fnmut2_borrow_mut_ctx(&());
+        let file: syn::File = syn::parse_quote!(fn main() { #expr });
+        insta::assert_snapshot!(prettyplease::unparse(&file));
+    }
+
+    #[test]
     fn test_crate_path_in_macro() {
         // This tests the fallback path (test module) with a relative path inside a macro call
         let quoted = q!(assert!(crate::my_top_level_function()));

--- a/stageleft_test/src/snapshots/stageleft_test__tests__splice_snapshot_fnmut2_borrow_mut.snap
+++ b/stageleft_test/src/snapshots/stageleft_test__tests__splice_snapshot_fnmut2_borrow_mut.snap
@@ -1,0 +1,15 @@
+---
+source: stageleft_test/src/lib.rs
+expression: "prettyplease::unparse(&file)"
+---
+fn main() {
+    stageleft::runtime_support::fnmut2_borrow_mut_type_hint::<
+        i32,
+        i32,
+        (),
+    >({
+        use crate::__staged::__deps::*;
+        use crate::__staged::tests::*;
+        { |state: &mut i32, item: i32| *state += item }
+    })
+}


### PR DESCRIPTION
Closes #83.

stageleft previously provided splice_fn2_borrow_mut_ctx / fn2_borrow_mut_type_hint
for closures of shape Fn(&mut I1, I2) -> O, but there was no FnMut counterpart,
preventing downstream operators (e.g. Hydro's scan/generator combinators) from
accepting mutable singleton reference captures (by_mut()).

Changes:
- stageleft/src/runtime_support.rs: add fnmut2_borrow_mut_type_hint for
  FnMut(&mut I1, I2) -> O closures, mirroring fn2_borrow_mut_type_hint.
- stageleft/src/lib.rs:
  - QuotedWithContextWithProps::splice_fnmut2_borrow_mut_ctx_props
  - QuotedWithContext::splice_fnmut2_borrow_mut_ctx and
    splice_fnmut2_borrow_mut convenience methods,
  all mirroring the existing splice_fn2_borrow_mut* methods but emitting
  fnmut2_borrow_mut_type_hint.
- stageleft_test/src/lib.rs: add a snapshot test exercising
  splice_fnmut2_borrow_mut_ctx, with the accepted insta snapshot.

Verified with cargo test (workspace) and cargo clippy --all-targets, all clean.