### PR TITLE
fix(stageleft_tool): resolve library root for rerun-if-changed instead of blindly emitting `src`

### DIFF
--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -640,6 +640,16 @@ pub fn gen_staged(gen_pub: bool) {
         .map(Path::new)
         .unwrap_or_else(|| Path::new("src/lib.rs"));
 
+    // Watch the directory containing the library root (usually `src`) so that changes to any
+    // module file trigger a rebuild. Blindly emitting `rerun-if-changed=src` would cause
+    // spurious rebuilds when a custom lib root is used and `src` does not exist, since Cargo
+    // treats missing paths as always-dirty.
+    let watch_path = lib_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty() && parent.is_dir())
+        .unwrap_or(lib_path);
+    println!("cargo::rerun-if-changed={}", watch_path.display());
+
     // Parse source once
     let flow_lib = syn_inline_mod::parse_and_inline_modules(lib_path);
 
@@ -652,7 +662,6 @@ pub fn gen_staged(gen_pub: bool) {
             prettyplease::unparse(&flow_lib_pub),
         )
         .unwrap();
-        println!("cargo::rerun-if-changed=src");
     }
 
     // Generate staged_deps.rs
@@ -719,7 +728,6 @@ pub fn gen_staged(gen_pub: bool) {
         registration_body.to_string(),
     )
     .unwrap();
-    println!("cargo::rerun-if-changed=src");
 }
 
 #[macro_export]


### PR DESCRIPTION
Fixes hydro-project/stageleft#82.

Previously, `gen_staged` emitted `cargo::rerun-if-changed=src` unconditionally
(in two places), even when the crate declared a custom `[lib] path` in its
`Cargo.toml`. When `src` does not exist, Cargo treats the missing path as
always-dirty, causing spurious rebuilds on every build.

Changes in `stageleft_tool/src/lib.rs`:
- Removed the two hardcoded `rerun-if-changed=src` prints.
- Emit a single `rerun-if-changed` directive derived from the already-resolved
  `lib_path`: watch the parent directory of the library root (normally `src`)
  so changes to any module file trigger a rebuild. If the lib root sits
  directly in the manifest dir (empty parent) or the parent isn't a directory,
  fall back to watching the lib root file itself rather than the whole crate
  directory (which could include `target/` and cause rebuild loops).

Verified:
- `cargo build --workspace` and `cargo test --workspace` pass.
- Default layout still emits `rerun-if-changed=src` and stays fresh on rebuilds.
- Simulated a crate with `[lib] path = "custom_root/lib.rs"` and no `src/`:
  it now emits `rerun-if-changed=custom_root`, second builds are fully fresh
  (no spurious rebuilds), and touching a source file still triggers a rebuild.