### PR TITLE
fix(stageleft): allow `use x as y;` and other `use` statements in `q!` macro

### DIFF
--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -705,6 +705,14 @@ impl<'a, T: 'a, Ctx, Props, F: FnOnce(&Ctx, &mut QuotedOutput, &mut Option<Props
 {
 }
 
+/// Prefix for path metavariable identifiers (`__sl_p0`, `__sl_p1`, ...) emitted by the
+/// `q!` macro in place of relative path prefixes (`crate::`, `self::`, `super::...`)
+/// inside a quoted block. The index `N` in `__sl_pN` is an index into
+/// [`QuotedOutput::relative_paths`](internal::QuotedOutput::relative_paths), which
+/// stores the original prefix so it can be resolved to a concrete path at splice time
+/// (the stageleft macro crate has a matching `PATH_METAVAR_PREFIX` constant).
+const PATH_METAVAR_PREFIX: &str = "__sl_p";
+
 /// Resolves a relative path string (e.g. "crate :: Foo :: bar", "self :: func", "super :: X")
 /// to the concrete rewritten path for the splice site.
 fn resolve_relative_path(
@@ -790,7 +798,7 @@ fn splice_quoted_output(output: &QuotedOutput) -> proc_macro2::TokenStream {
         .iter()
         .enumerate()
         .map(|(idx, p)| {
-            let name = syn::Ident::new(&format!("__sl_p{idx}"), Span::call_site());
+            let name = syn::Ident::new(&format!("{PATH_METAVAR_PREFIX}{idx}"), Span::call_site());
             quote!(#name = #p)
         })
         .collect();
@@ -845,16 +853,24 @@ fn splice_quoted_output(output: &QuotedOutput) -> proc_macro2::TokenStream {
                     struct MetavarRewriter<'a> {
                         path_args: &'a [proc_macro2::TokenStream],
                     }
+                    impl MetavarRewriter<'_> {
+                        /// If `ident` is a path metavar (`__sl_pN`), returns the
+                        /// resolved path for index `N`.
+                        fn resolve_metavar(&self, ident: &syn::Ident) -> Option<syn::Path> {
+                            let idx = ident
+                                .to_string()
+                                .strip_prefix(PATH_METAVAR_PREFIX)?
+                                .parse::<usize>()
+                                .ok()?;
+                            let resolved = self.path_args.get(idx)?;
+                            Some(syn::parse2(resolved.clone()).unwrap())
+                        }
+                    }
                     impl VisitMut for MetavarRewriter<'_> {
                         fn visit_path_mut(&mut self, path: &mut syn::Path) {
                             if let Some(first) = path.segments.first()
-                                && let Some(idx_str) =
-                                    first.ident.to_string().strip_prefix("__sl_p")
-                                && let Ok(idx) = idx_str.parse::<usize>()
-                                && let Some(resolved) = self.path_args.get(idx)
+                                && let Some(resolved_path) = self.resolve_metavar(&first.ident)
                             {
-                                let resolved_path: syn::Path =
-                                    syn::parse2(resolved.clone()).unwrap();
                                 let remaining: Vec<_> =
                                     path.segments.iter().skip(1).cloned().collect();
                                 *path = resolved_path;
@@ -863,6 +879,22 @@ fn splice_quoted_output(output: &QuotedOutput) -> proc_macro2::TokenStream {
                                 }
                             }
                             syn::visit_mut::visit_path_mut(self, path);
+                        }
+
+                        fn visit_item_use_mut(&mut self, i: &mut syn::ItemUse) {
+                            if let syn::UseTree::Path(first) = &i.tree
+                                && let Some(resolved_path) = self.resolve_metavar(&first.ident)
+                            {
+                                let mut tree = (*first.tree).clone();
+                                for seg in resolved_path.segments.iter().rev() {
+                                    tree = syn::UseTree::Path(syn::UsePath {
+                                        ident: seg.ident.clone(),
+                                        colon2_token: Default::default(),
+                                        tree: Box::new(tree),
+                                    });
+                                }
+                                i.tree = tree;
+                            }
                         }
 
                         fn visit_macro_mut(&mut self, i: &mut syn::Macro) {

--- a/stageleft_macro/src/quote_impl/free_variable/mod.rs
+++ b/stageleft_macro/src/quote_impl/free_variable/mod.rs
@@ -67,6 +67,75 @@ pub struct FreeVariableVisitor {
     pub rewrite_paths: bool,
 }
 
+impl FreeVariableVisitor {
+    /// If `idents` (the leading idents of a path with no leading `::`) starts with a
+    /// relative prefix (`crate`, or a run of `self` / `super`), registers the prefix
+    /// in `relative_paths` and returns the number of prefix idents together with the
+    /// `__sl_pN` metavar ident that should replace them. Returns `None` if the path
+    /// is not relative.
+    fn relative_prefix_metavar<'a>(
+        &mut self,
+        idents: impl IntoIterator<Item = &'a syn::Ident>,
+    ) -> Option<(usize, syn::Ident)> {
+        let mut idents = idents.into_iter();
+        let first = idents.next()?;
+        if *first != "crate" && *first != "self" && *first != "super" {
+            return None;
+        }
+
+        let mut prefix = vec![first.clone()];
+        if *first != "crate" {
+            prefix.extend(
+                idents
+                    .take_while(|i| **i == "self" || **i == "super")
+                    .cloned(),
+            );
+        }
+
+        let key = quote::quote!(#(#prefix)::*).to_string();
+        let next_idx = self.relative_paths.len();
+        let idx = *self.relative_paths.entry(key).or_insert(next_idx);
+        Some((prefix.len(), super::path_metavar(idx)))
+    }
+}
+
+/// Registers the names bound by a `use` tree (e.g. `y` in `use x as y;`) into
+/// the given scope so that later references to them are not treated as free
+/// variables. `parent` is the ident of the enclosing path segment, used to
+/// resolve `use foo::bar::{self}` (which binds `bar`).
+fn register_use_tree_bindings(
+    tree: &syn::UseTree,
+    parent: Option<&syn::Ident>,
+    scope: &mut ScopeStack,
+) {
+    match tree {
+        syn::UseTree::Path(path) => {
+            register_use_tree_bindings(&path.tree, Some(&path.ident), scope);
+        }
+        syn::UseTree::Name(name) => {
+            let bound = if name.ident == "self" {
+                parent
+            } else {
+                Some(&name.ident)
+            };
+            if let Some(bound) = bound {
+                scope.insert_term(bound.clone());
+                scope.insert_type(bound.clone());
+            }
+        }
+        syn::UseTree::Rename(rename) => {
+            scope.insert_term(rename.rename.clone());
+            scope.insert_type(rename.rename.clone());
+        }
+        syn::UseTree::Glob(_) => {}
+        syn::UseTree::Group(group) => {
+            for tree in &group.items {
+                register_use_tree_bindings(tree, parent, scope);
+            }
+        }
+    }
+}
+
 /// Visitor that only extracts bound identifiers from patterns,
 /// without triggering free variable detection on paths like `Some`.
 struct PatBindingVisitor<'a> {
@@ -130,6 +199,47 @@ impl syn::visit_mut::VisitMut for FreeVariableVisitor {
         syn::visit::Visit::visit_pat(&mut binding_visitor, &i.pat);
     }
 
+    fn visit_item_use_mut(&mut self, i: &mut syn::ItemUse) {
+        // Rewrite relative path prefixes (crate::, self::, super::) in the use
+        // tree, mirroring the logic in `visit_path_mut`.
+        if self.rewrite_paths && i.leading_colon.is_none() {
+            // Collect the idents of the leading `UseTree::Path` chain.
+            let mut leading = Vec::new();
+            let mut cursor = &i.tree;
+            while let syn::UseTree::Path(path) = cursor {
+                leading.push(path.ident.clone());
+                cursor = &path.tree;
+            }
+
+            if let Some((prefix_len, metavar)) = self.relative_prefix_metavar(&leading) {
+                // Peel off the prefix segments and reattach the remainder under the metavar.
+                let mut remaining = std::mem::replace(
+                    &mut i.tree,
+                    syn::UseTree::Glob(syn::UseGlob {
+                        star_token: Default::default(),
+                    }),
+                );
+                for _ in 0..prefix_len {
+                    remaining = match remaining {
+                        syn::UseTree::Path(path) => *path.tree,
+                        _ => unreachable!("prefix segments are always `UseTree::Path`"),
+                    };
+                }
+                i.tree = syn::UseTree::Path(syn::UsePath {
+                    ident: metavar,
+                    colon2_token: Default::default(),
+                    tree: Box::new(remaining),
+                });
+            }
+        }
+
+        // The idents in a `use` path refer to crates / modules / items, never
+        // to local variables, so they must not be captured as free variables
+        // (and must not be renamed to `x__free`). Instead, register the names
+        // the `use` binds so later references to them are not captured either.
+        register_use_tree_bindings(&i.tree, None, &mut self.current_scope);
+    }
+
     fn visit_ident_mut(&mut self, i: &mut proc_macro2::Ident) {
         if !self.current_scope.contains_term(i) {
             self.free_variables.insert(i.clone());
@@ -149,23 +259,9 @@ impl syn::visit_mut::VisitMut for FreeVariableVisitor {
         if self.rewrite_paths
             && i.leading_colon.is_none()
             && i.segments.len() > 1
-            && let Some(first) = i.segments.first()
-            && (first.ident == "crate" || first.ident == "self" || first.ident == "super")
+            && let Some((prefix_len, metavar)) =
+                self.relative_prefix_metavar(i.segments.iter().map(|s| &s.ident))
         {
-            let prefix_len = if first.ident == "crate" {
-                1
-            } else {
-                i.segments
-                    .iter()
-                    .take_while(|s| s.ident == "self" || s.ident == "super")
-                    .count()
-            };
-            let prefix_segments: Vec<_> = i.segments.iter().take(prefix_len).collect();
-            let key = quote::quote!(#(#prefix_segments)::*).to_string();
-            let next_idx = self.relative_paths.len();
-            let idx = *self.relative_paths.entry(key).or_insert(next_idx);
-
-            let metavar = syn::Ident::new(&format!("__sl_p{idx}"), proc_macro2::Span::call_site());
             let remaining: Vec<_> = i.segments.iter().skip(prefix_len).cloned().collect();
             i.segments.clear();
             i.segments.push(syn::PathSegment::from(metavar));

--- a/stageleft_macro/src/quote_impl/mod.rs
+++ b/stageleft_macro/src/quote_impl/mod.rs
@@ -11,6 +11,19 @@ use self::free_variable::FreeVariableVisitor;
 mod attempt_transform_macro;
 mod free_variable;
 
+/// Prefix for path metavariable identifiers (`__sl_p0`, `__sl_p1`, ...) that stand in
+/// for relative path prefixes (`crate::`, `self::`, `super::...`) inside a quoted
+/// block. The index `N` in `__sl_pN` is an index into the recorded
+/// `QuotedOutput::relative_paths`, which stores the original prefix so that it can be
+/// resolved to a concrete path at splice time (the stageleft runtime crate has a
+/// matching `PATH_METAVAR_PREFIX` constant).
+pub(crate) const PATH_METAVAR_PREFIX: &str = "__sl_p";
+
+/// Creates the `__sl_pN` metavar ident for the given `relative_paths` index.
+pub(crate) fn path_metavar(idx: usize) -> syn::Ident {
+    syn::Ident::new(&format!("{PATH_METAVAR_PREFIX}{idx}"), Span::call_site())
+}
+
 /// A property annotation like `commutative = Kani` or `idempotent = ManualProof(/** something */)`
 struct PropertyAnnotation {
     name: syn::Ident,
@@ -59,7 +72,7 @@ fn rewrite_body_for_macro(
 ) -> TokenStream {
     let metavar_idents: std::collections::HashSet<String> = relative_paths
         .values()
-        .map(|idx| format!("__sl_p{idx}"))
+        .map(|idx| format!("{PATH_METAVAR_PREFIX}{idx}"))
         .collect();
 
     fn rewrite_stream(
@@ -182,7 +195,7 @@ pub fn q_impl(root: TokenStream, toks: TokenStream) -> TokenStream {
             sorted
                 .iter()
                 .map(|(_, idx)| {
-                    let metavar = syn::Ident::new(&format!("__sl_p{idx}"), Span::call_site());
+                    let metavar = path_metavar(**idx);
                     quote!(#metavar = $($#metavar:ident)::*)
                 })
                 .collect()
@@ -318,7 +331,7 @@ pub fn q_impl(root: TokenStream, toks: TokenStream) -> TokenStream {
                 .iter()
                 .map(|(prefix_str, idx)| {
                     let prefix: syn::Path = syn::parse_str(prefix_str).unwrap();
-                    let name = syn::Ident::new(&format!("__sl_p{idx}"), Span::call_site());
+                    let name = path_metavar(**idx);
                     quote!(#name = #prefix)
                 })
                 .collect()
@@ -500,6 +513,48 @@ mod tests {
 
         test_quote! {
             Err(1)
+        }
+    }
+
+    #[test]
+    fn test_use_rename() {
+        test_quote! {
+            {
+                use std::collections::HashMap as MyMap;
+                MyMap::<u32, u32>::new()
+            }
+        }
+    }
+
+    #[test]
+    fn test_use_group() {
+        test_quote! {
+            {
+                use std::collections::{HashMap, hash_map::{self}, HashSet as MySet};
+                let map: HashMap<u32, u32> = HashMap::new();
+                let _: hash_map::Iter<u32, u32> = map.iter();
+                MySet::<u32>::new()
+            }
+        }
+    }
+
+    #[test]
+    fn test_use_crate_path() {
+        test_quote! {
+            {
+                use crate::submodule::MyStruct as TheStruct;
+                TheStruct::new()
+            }
+        }
+    }
+
+    #[test]
+    fn test_use_super_path() {
+        test_quote! {
+            {
+                use super::super::MyStruct;
+                MyStruct::new()
+            }
         }
     }
 }

--- a/stageleft_macro/src/quote_impl/snapshots/use_crate_path@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/use_crate_path@macro_tokens.snap
@@ -1,0 +1,45 @@
+---
+source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 530
+expression: "prettyplease :: unparse(& wrapped)"
+---
+fn main() {
+    {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            (
+                [__sl_p0 = $($__sl_p0:ident)::*,] [{ use __sl_p0::submodule::MyStruct as
+                TheStruct; TheStruct::new() }]
+            ) => {
+                { #[allow(non_snake_case)] { { use $($__sl_p0)::* ::submodule::MyStruct
+                as TheStruct; TheStruct::new() } } }
+            };
+        }
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
+            if true {
+                __output.module_path = module_path!();
+                __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
+                __output.tokens = "{ use __sl_p0 :: submodule :: MyStruct as TheStruct ; TheStruct :: new () }";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &["crate"];
+                *__props = Some(stageleft::properties::Property::make_root(__props));
+                ::core::panic!("stageleft: q!() closure completed");
+            }
+            #[allow(unreachable_code, unused_qualifications)]
+            {
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [__sl_p0 = crate,] [{ use __sl_p0::submodule::MyStruct as TheStruct;
+                    TheStruct::new() }]
+                )
+            }
+        }
+    }
+}

--- a/stageleft_macro/src/quote_impl/snapshots/use_group@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/use_group@macro_tokens.snap
@@ -1,0 +1,49 @@
+---
+source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 518
+expression: "prettyplease :: unparse(& wrapped)"
+---
+fn main() {
+    {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            (
+                [] [{ use std::collections:: { HashMap, hash_map:: { self }, HashSet as
+                MySet }; let map : HashMap < u32, u32 > = HashMap::new(); let _ :
+                hash_map::Iter < u32, u32 > = map . iter(); MySet:: < u32 > ::new() }]
+            ) => {
+                { #[allow(non_snake_case)] { { use std::collections:: { HashMap,
+                hash_map:: { self }, HashSet as MySet }; let map : HashMap < u32, u32 > =
+                HashMap::new(); let _ : hash_map::Iter < u32, u32 > = map.iter(); MySet::
+                < u32 > ::new() } } }
+            };
+        }
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
+            if true {
+                __output.module_path = module_path!();
+                __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
+                __output.tokens = "{ use std :: collections :: { HashMap , hash_map :: { self } , HashSet as MySet } ; let map : HashMap < u32 , u32 > = HashMap :: new () ; let _ : hash_map :: Iter < u32 , u32 > = map . iter () ; MySet :: < u32 > :: new () }";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
+                *__props = Some(stageleft::properties::Property::make_root(__props));
+                ::core::panic!("stageleft: q!() closure completed");
+            }
+            #[allow(unreachable_code, unused_qualifications)]
+            {
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [] [{ use std::collections:: { HashMap, hash_map:: { self }, HashSet
+                    as MySet }; let map : HashMap < u32, u32 > = HashMap::new(); let _ :
+                    hash_map::Iter < u32, u32 > = map.iter(); MySet:: < u32 > ::new() }]
+                )
+            }
+        }
+    }
+}

--- a/stageleft_macro/src/quote_impl/snapshots/use_rename@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/use_rename@macro_tokens.snap
@@ -1,0 +1,45 @@
+---
+source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 508
+expression: "prettyplease :: unparse(& wrapped)"
+---
+fn main() {
+    {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            (
+                [] [{ use std::collections::HashMap as MyMap; MyMap:: < u32, u32 >
+                ::new() }]
+            ) => {
+                { #[allow(non_snake_case)] { { use std::collections::HashMap as MyMap;
+                MyMap:: < u32, u32 > ::new() } } }
+            };
+        }
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
+            if true {
+                __output.module_path = module_path!();
+                __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
+                __output.tokens = "{ use std :: collections :: HashMap as MyMap ; MyMap :: < u32 , u32 > :: new () }";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &[];
+                *__props = Some(stageleft::properties::Property::make_root(__props));
+                ::core::panic!("stageleft: q!() closure completed");
+            }
+            #[allow(unreachable_code, unused_qualifications)]
+            {
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [] [{ use std::collections::HashMap as MyMap; MyMap:: < u32, u32 >
+                    ::new() }]
+                )
+            }
+        }
+    }
+}

--- a/stageleft_macro/src/quote_impl/snapshots/use_super_path@macro_tokens.snap
+++ b/stageleft_macro/src/quote_impl/snapshots/use_super_path@macro_tokens.snap
@@ -1,0 +1,45 @@
+---
+source: stageleft_macro/src/quote_impl/mod.rs
+assertion_line: 540
+expression: "prettyplease :: unparse(& wrapped)"
+---
+fn main() {
+    {
+        #[allow(unexpected_cfgs, non_local_definitions, clippy::crate_in_macro_def)]
+        #[cfg_attr(not(stageleft_macro), macro_export)]
+        #[doc(hidden)]
+        macro_rules! __stageleft_quote__parsed_string_1__1_0 {
+            (
+                [__sl_p0 = $($__sl_p0:ident)::*,] [{ use __sl_p0::MyStruct;
+                MyStruct::new() }]
+            ) => {
+                { #[allow(non_snake_case)] { { use $($__sl_p0)::* ::MyStruct;
+                MyStruct::new() } } }
+            };
+        }
+        move |
+            __stageleft_ctx: &_,
+            __output: &mut ::stageleft::internal::QuotedOutput,
+            __props: &mut _|
+        {
+            if true {
+                __output.module_path = module_path!();
+                __output.crate_name = option_env!("STAGELEFT_FINAL_CRATE_NAME")
+                    .unwrap_or(env!("CARGO_PKG_NAME"));
+                __output.pkg_name = env!("CARGO_PKG_NAME");
+                __output.tokens = "{ use __sl_p0 :: MyStruct ; MyStruct :: new () }";
+                __output.macro_name = Some("__stageleft_quote__parsed_string_1__1_0");
+                __output.relative_paths = &["super :: super"];
+                *__props = Some(stageleft::properties::Property::make_root(__props));
+                ::core::panic!("stageleft: q!() closure completed");
+            }
+            #[allow(unreachable_code, unused_qualifications)]
+            {
+                __stageleft_quote__parsed_string_1__1_0!(
+                    [__sl_p0 = super::super,] [{ use __sl_p0::MyStruct; MyStruct::new()
+                    }]
+                )
+            }
+        }
+    }
+}

--- a/stageleft_test/src/lib.rs
+++ b/stageleft_test/src/lib.rs
@@ -86,6 +86,24 @@ pub fn self_path_at_root<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
 }
 
 #[stageleft::entry]
+pub fn use_rename<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, usize> {
+    q!({
+        use std::collections::HashSet as MySet;
+        let mut set = MySet::new();
+        set.insert(123);
+        set.len()
+    })
+}
+
+#[stageleft::entry]
+pub fn use_crate_path<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
+    q!({
+        use crate::my_top_level_function as renamed_function;
+        renamed_function()
+    })
+}
+
+#[stageleft::entry]
 fn captured_closure<'a>(_ctx: BorrowBounds<'a>) -> impl Quoted<'a, bool> {
     let closure = q!(|| true);
     q!({
@@ -142,6 +160,29 @@ mod tests {
     #[test]
     fn test_self_path_at_root() {
         assert!(self_path_at_root!());
+    }
+
+    #[test]
+    fn test_use_rename() {
+        assert_eq!(use_rename!(), 1);
+    }
+
+    #[test]
+    fn test_use_crate_path() {
+        assert!(use_crate_path!());
+    }
+
+    #[test]
+    fn test_use_crate_path_in_test_module() {
+        // This tests the fallback path (test module) with a `use` statement that
+        // has a relative path prefix
+        let quoted = q!({
+            use crate::my_top_level_function as renamed_function;
+            renamed_function()
+        });
+        let expr = quoted.splice_untyped_ctx(&());
+        let file: syn::File = syn::parse_quote!(fn main() { #expr });
+        insta::assert_snapshot!(prettyplease::unparse(&file));
     }
 
     #[test]

--- a/stageleft_test/src/snapshots/stageleft_test__tests__use_crate_path_in_test_module.snap
+++ b/stageleft_test/src/snapshots/stageleft_test__tests__use_crate_path_in_test_module.snap
@@ -1,0 +1,17 @@
+---
+source: stageleft_test/src/lib.rs
+assertion_line: 185
+expression: "prettyplease::unparse(&file)"
+---
+fn main() {
+    {
+        use crate::__staged::__deps::*;
+        use crate::__staged::tests::*;
+        {
+            {
+                use crate::__staged::my_top_level_function as renamed_function;
+                renamed_function()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes hydro-project/stageleft#57.

Previously, `use` statements inside a `q!` block were traversed by the
default syn visitor, so every ident in the use tree was treated as a free
variable and mangled to `x__free`, producing errors like
"unresolved import `x__free`: no external crate `x__free`".

Changes:

- `stageleft_macro/src/quote_impl/free_variable/mod.rs`: added a
  `visit_item_use_mut` override on `FreeVariableVisitor` that:
  - leaves use-path idents untouched (they refer to crates/modules/items,
    never to capturable local variables);
  - registers the names bound by the `use` (including renames, groups, and
    `{self}` imports) into the current scope, so later references to them
    inside the quoted block are not captured as free variables;
  - rewrites relative prefixes (`crate::`, `self::`, `super::...`) in use
    trees to `__sl_pN` path metavars, mirroring the existing logic in
    `visit_path_mut`, so imports like `use crate::foo::Bar;` resolve
    correctly at the splice site.

- `stageleft/src/lib.rs`: taught the fallback `MetavarRewriter` (used when
  splicing inside test modules / outside the crate) to resolve `__sl_pN`
  prefixes inside `use` trees, since `syn::visit_mut` does not surface use
  trees as `syn::Path`.

- Tests:
  - macro snapshot tests for `use ... as ...`, use groups with `{self}` and
    renames, and `crate::`/`super::super::` prefixed uses;
  - end-to-end entry tests in `stageleft_test` (`use_rename`,
    `use_crate_path`) plus a splice snapshot test exercising the fallback
    rewriter with a relative-path `use`.