### PR TITLE
fix(stageleft): upgrade to ctor 1.0 to fix Miri UB in generated ctors (#84)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,19 +56,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.4.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e9666f4a9a948d4f1dff0c08a4512b0f7c86414b23960104c243c10d79f4c3"
-dependencies = [
- "ctor-proc-macro",
- "dtor",
-]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
+checksum = "fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb"
 
 [[package]]
 name = "digest"
@@ -79,21 +69,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
-
-[[package]]
-name = "dtor"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222ef136a1c687d4aa0395c175f2c4586e379924c352fd02f7870cf7de783c23"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "encode_unicode"

--- a/stageleft/Cargo.toml
+++ b/stageleft/Cargo.toml
@@ -20,7 +20,7 @@ syn = { version = "2", features = [ "full", "visit-mut" ] }
 proc-macro2 = "1"
 proc-macro-crate = "3.3"
 stageleft_macro = { path = "../stageleft_macro", version = "^0.14.3" }
-ctor = "0.4.1"
+ctor = { version = "1.0.8", default-features = false, features = ["std"] }
 parking_lot = "0.12"
 
 [dev-dependencies]

--- a/stageleft/src/lib.rs
+++ b/stageleft/src/lib.rs
@@ -109,14 +109,16 @@ macro_rules! stageleft_no_entry_crate {
         }
 
         #[cfg(test)]
-        #[$crate::internal::ctor::ctor(crate_path = $crate::internal::ctor)]
-        fn __stageleft_register_test_modules() {
-            let (crate_name, modules) = include!(concat!(
-                env!("OUT_DIR"),
-                $crate::PATH_SEPARATOR!(),
-                "test_modules.rs"
-            ));
-            $crate::runtime_support::register_test_modules(crate_name, modules);
+        $crate::internal::ctor::declarative::ctor! {
+            #[ctor(unsafe)]
+            fn __stageleft_register_test_modules() {
+                let (crate_name, modules) = include!(concat!(
+                    env!("OUT_DIR"),
+                    $crate::PATH_SEPARATOR!(),
+                    "test_modules.rs"
+                ));
+                $crate::runtime_support::register_test_modules(crate_name, modules);
+            }
         }
     };
 }

--- a/stageleft_test_no_entry/tests/snapshots/codegen_snapshot__staged_deps.snap
+++ b/stageleft_test_no_entry/tests/snapshots/codegen_snapshot__staged_deps.snap
@@ -9,64 +9,29 @@ pub mod __deps {
     pub use once_cell;
     #[cfg(any(feature = "my_cfg_feature"))]
     pub use cfg_if;
-    #[stageleft::internal::ctor::ctor(crate_path = stageleft::internal::ctor)]
-    fn __init() {
-        {
-            stageleft::internal::add_deps_reexport(
-                vec!["stageleft"],
-                vec![
-                    option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                        .unwrap_or(env!("CARGO_PKG_NAME"))
-                        .replace("-", "_"),
-                    ::std::borrow::ToOwned::to_owned("__staged"),
-                    ::std::borrow::ToOwned::to_owned("__deps"),
-                    ::std::borrow::ToOwned::to_owned("stageleft"),
-                ],
-            );
-        }
-        {
-            stageleft::internal::add_deps_reexport(
-                vec!["slotmap"],
-                vec![
-                    option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                        .unwrap_or(env!("CARGO_PKG_NAME"))
-                        .replace("-", "_"),
-                    ::std::borrow::ToOwned::to_owned("__staged"),
-                    ::std::borrow::ToOwned::to_owned("__deps"),
-                    ::std::borrow::ToOwned::to_owned("slotmap"),
-                ],
-            );
-        }
-        #[cfg(any(feature = "once_cell"))]
-        {
-            stageleft::internal::add_deps_reexport(
-                vec!["once_cell"],
-                vec![
-                    option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                        .unwrap_or(env!("CARGO_PKG_NAME"))
-                        .replace("-", "_"),
-                    ::std::borrow::ToOwned::to_owned("__staged"),
-                    ::std::borrow::ToOwned::to_owned("__deps"),
-                    ::std::borrow::ToOwned::to_owned("once_cell"),
-                ],
-            );
-        }
-        #[cfg(any(feature = "my_cfg_feature"))]
-        {
-            stageleft::internal::add_deps_reexport(
-                vec!["cfg_if"],
-                vec![
-                    option_env!("STAGELEFT_FINAL_CRATE_NAME")
-                        .unwrap_or(env!("CARGO_PKG_NAME"))
-                        .replace("-", "_"),
-                    ::std::borrow::ToOwned::to_owned("__staged"),
-                    ::std::borrow::ToOwned::to_owned("__deps"),
-                    ::std::borrow::ToOwned::to_owned("cfg_if"),
-                ],
-            );
-        }
-        stageleft::internal::add_crate_with_staged(
-            env!("CARGO_PKG_NAME").replace("-", "_"),
-        );
+    stageleft::internal::ctor::declarative::ctor! {
+        #[ctor(unsafe)] fn __init() { {
+        stageleft::internal::add_deps_reexport(vec!["stageleft"],
+        vec![option_env!("STAGELEFT_FINAL_CRATE_NAME") .unwrap_or(env!("CARGO_PKG_NAME"))
+        .replace("-", "_"), ::std::borrow::ToOwned::to_owned("__staged"),
+        ::std::borrow::ToOwned::to_owned("__deps"),
+        ::std::borrow::ToOwned::to_owned("stageleft"),]); } {
+        stageleft::internal::add_deps_reexport(vec!["slotmap"],
+        vec![option_env!("STAGELEFT_FINAL_CRATE_NAME") .unwrap_or(env!("CARGO_PKG_NAME"))
+        .replace("-", "_"), ::std::borrow::ToOwned::to_owned("__staged"),
+        ::std::borrow::ToOwned::to_owned("__deps"),
+        ::std::borrow::ToOwned::to_owned("slotmap"),]); } #[cfg(any(feature =
+        "once_cell"))] { stageleft::internal::add_deps_reexport(vec!["once_cell"],
+        vec![option_env!("STAGELEFT_FINAL_CRATE_NAME") .unwrap_or(env!("CARGO_PKG_NAME"))
+        .replace("-", "_"), ::std::borrow::ToOwned::to_owned("__staged"),
+        ::std::borrow::ToOwned::to_owned("__deps"),
+        ::std::borrow::ToOwned::to_owned("once_cell"),]); } #[cfg(any(feature =
+        "my_cfg_feature"))] { stageleft::internal::add_deps_reexport(vec!["cfg_if"],
+        vec![option_env!("STAGELEFT_FINAL_CRATE_NAME") .unwrap_or(env!("CARGO_PKG_NAME"))
+        .replace("-", "_"), ::std::borrow::ToOwned::to_owned("__staged"),
+        ::std::borrow::ToOwned::to_owned("__deps"),
+        ::std::borrow::ToOwned::to_owned("cfg_if"),]); }
+        stageleft::internal::add_crate_with_staged(env!("CARGO_PKG_NAME") .replace("-",
+        "_")); }
     }
 }

--- a/stageleft_tool/src/lib.rs
+++ b/stageleft_tool/src/lib.rs
@@ -356,6 +356,19 @@ impl VisitMut for GenFinalPubVisitor {
                     *i = syn::Item::Verbatim(Default::default());
                     return;
                 }
+
+                let is_ctor = m
+                    .mac
+                    .path
+                    .to_token_stream()
+                    .to_string()
+                    .ends_with("ctor :: declarative :: ctor");
+
+                if is_ctor {
+                    // no quoted code depends on this module, so we do not need to copy it
+                    *i = syn::Item::Verbatim(Default::default());
+                    return;
+                }
             }
             syn::Item::Impl(_e) => {
                 // TODO(shadaj): emit impls if the **struct** is private
@@ -534,10 +547,12 @@ fn gen_deps_module(stageleft_name: syn::Ident, manifest_path: &Path) -> syn::Ite
         pub mod __deps {
             #(#deps_reexported)*
 
-            #[#stageleft_name::internal::ctor::ctor(crate_path = #stageleft_name::internal::ctor)]
-            fn __init() {
-                #(#deps_reexported_runtime)*
-                #stageleft_name::internal::add_crate_with_staged(env!("CARGO_PKG_NAME").replace("-", "_"));
+            #stageleft_name::internal::ctor::declarative::ctor! {
+                #[ctor(unsafe)]
+                fn __init() {
+                    #(#deps_reexported_runtime)*
+                    #stageleft_name::internal::add_crate_with_staged(env!("CARGO_PKG_NAME").replace("-", "_"));
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #84

Any crate linking against a stageleft crate could not run under Miri:
the generated `staged_deps.rs` registers an unconditional `#[ctor]`
function, and ctor 0.4.x declares `.init_array` entries with a
glibc-specific `extern "C" fn() -> usize` signature that trips Miri's
strict ABI check before any test code runs.

Upgrade `ctor` from 0.4.1 to 1.0.8, whose generated entries use a plain
`extern fn()` signature that Miri accepts (ctor 1.0 runs Miri in its own
CI). Verified that `cargo +nightly miri test` now reaches test execution
cleanly, so no `cfg(not(miri))` gating is needed.

Also switch all generated constructors to ctor's declarative macro form,
recommended for crates that re-export ctor:

- stageleft/Cargo.toml: `ctor = "0.4.1"` → `ctor = { version = "1.0.8",
  default-features = false, features = ["std"] }`. Disabling default
  features drops the proc-macro and priority machinery; ctor is now a
  zero-dependency crate in our tree (removes ctor-proc-macro, dtor, and
  dtor-proc-macro).

- stageleft/src/lib.rs: `stageleft_no_entry_crate!` emits the test
  module registration ctor via
  `$crate::internal::ctor::declarative::ctor! { #[ctor(unsafe)] fn ... }`.
  The declarative macro resolves its internals via `$crate`, so the
  `crate_path = ...` parameter is no longer needed. (`#[ctor(unsafe)]`
  is mandatory in ctor 1.0.)

- stageleft_tool/src/lib.rs: the generated `__init` in `staged_deps.rs`
  uses the same declarative form. Also taught the staged-code visitor to
  strip user-written declarative `ctor::declarative::ctor! { ... }`
  invocations (in addition to the existing `#[ctor::ctor]` attribute
  detection) so they aren't copied into `__staged` modules.

- Regenerated the codegen_snapshot__staged_deps.snap snapshot.

Verified: cargo test --workspace (44 passed), clippy clean, fmt clean,
and `cargo +nightly miri test` on stageleft_test_no_entry starts up and
runs tests instead of aborting with UB at process init. (The snapshot
test itself fails under Miri only due to insta's file I/O being blocked
by Miri isolation, unrelated to ctors.)